### PR TITLE
v0.1: WebSocket byte-stream adapter (AsyncRead + AsyncWrite)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "boring"
 version = "4.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -80,6 +89,12 @@ dependencies = [
  "fs_extra",
  "fslock",
 ]
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -133,12 +148,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -149,15 +199,19 @@ dependencies = [
  "arc-swap",
  "boring",
  "bytes",
+ "futures-util",
  "http",
  "http-body-util",
  "libc",
+ "pin-project-lite",
  "rcgen",
  "socket2 0.5.10",
  "tempfile",
  "tokio",
  "tokio-boring",
+ "tokio-tungstenite",
  "tracing",
+ "tungstenite",
 ]
 
 [[package]]
@@ -250,6 +304,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -332,6 +421,12 @@ dependencies = [
  "http-body",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "id-arena"
@@ -479,6 +574,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -511,6 +615,36 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "rcgen"
@@ -651,10 +785,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "socket2"
@@ -698,6 +849,26 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -757,6 +928,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -788,6 +971,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror",
+ "utf-8",
+]
+
+[[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -804,6 +1011,18 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"
@@ -1074,6 +1293,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
  "time",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,17 @@ anyhow = "1"
 arc-swap = "1"
 boring = "4"
 bytes = "1"
+futures-util = { version = "0.3", default-features = false, features = ["sink"] }
 http = "1"
 http-body-util = "0.1"
 libc = "0.2"
+pin-project-lite = "0.2"
 socket2 = { version = "0.5", features = ["all"] }
 tokio = { version = "1", features = ["net", "rt-multi-thread", "macros", "io-util"] }
 tokio-boring = "4"
+tokio-tungstenite = "0.24"
 tracing = "0.1"
+tungstenite = "0.24"
 
 [dev-dependencies]
 rcgen = "0.13"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,3 +10,4 @@ pub mod sip003;
 pub mod stealth;
 pub mod tls_client;
 pub mod tls_server;
+pub mod ws;

--- a/src/ws.rs
+++ b/src/ws.rs
@@ -1,0 +1,212 @@
+//! WebSocket byte-stream adapter.
+//!
+//! Wraps a [`WebSocketStream`] so that it implements
+//! `AsyncRead + AsyncWrite`, letting [`tokio::io::copy_bidirectional`]
+//! shovel raw bytes between a WS connection and a plain TCP socket
+//! (the SIP003 upstream/downstream).
+//!
+//! - Writes become Binary frames.
+//! - Reads concatenate Binary and Text frame payloads (shadowsocks data
+//!   is binary; we accept Text purely to avoid breaking on a peer that
+//!   misuses it).
+//! - Pings are auto-ponged inside `tungstenite`.
+//! - A Close frame from the peer surfaces as EOF on the read side.
+
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use bytes::Bytes;
+use futures_util::{Sink, Stream};
+use pin_project_lite::pin_project;
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::WebSocketStream;
+
+pin_project! {
+    /// `AsyncRead + AsyncWrite` wrapper around a [`WebSocketStream`].
+    pub struct WsByteStream<S> {
+        #[pin]
+        inner: WebSocketStream<S>,
+        read_buf: Bytes,
+        eof: bool,
+    }
+}
+
+impl<S> WsByteStream<S> {
+    pub fn new(inner: WebSocketStream<S>) -> Self {
+        Self {
+            inner,
+            read_buf: Bytes::new(),
+            eof: false,
+        }
+    }
+
+    pub fn into_inner(self) -> WebSocketStream<S> {
+        self.inner
+    }
+}
+
+impl<S: AsyncRead + AsyncWrite + Unpin> AsyncRead for WsByteStream<S> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        let mut this = self.project();
+        loop {
+            if !this.read_buf.is_empty() {
+                let n = buf.remaining().min(this.read_buf.len());
+                buf.put_slice(&this.read_buf[..n]);
+                *this.read_buf = this.read_buf.slice(n..);
+                return Poll::Ready(Ok(()));
+            }
+            if *this.eof {
+                return Poll::Ready(Ok(())); // EOF
+            }
+            match this.inner.as_mut().poll_next(cx) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(None) => {
+                    *this.eof = true;
+                    return Poll::Ready(Ok(()));
+                }
+                Poll::Ready(Some(Ok(msg))) => match msg {
+                    Message::Binary(data) => {
+                        *this.read_buf = Bytes::from(data);
+                    }
+                    Message::Text(s) => {
+                        *this.read_buf = Bytes::from(s.into_bytes());
+                    }
+                    Message::Close(_) => {
+                        *this.eof = true;
+                    }
+                    Message::Ping(_) | Message::Pong(_) | Message::Frame(_) => {
+                        // tungstenite handles ping replies; just keep reading.
+                    }
+                },
+                Poll::Ready(Some(Err(e))) => return Poll::Ready(Err(io_err(e))),
+            }
+        }
+    }
+}
+
+impl<S: AsyncRead + AsyncWrite + Unpin> AsyncWrite for WsByteStream<S> {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        let mut this = self.project();
+        match this.inner.as_mut().poll_ready(cx) {
+            Poll::Pending => return Poll::Pending,
+            Poll::Ready(Err(e)) => return Poll::Ready(Err(io_err(e))),
+            Poll::Ready(Ok(())) => {}
+        }
+        let msg = Message::Binary(buf.to_vec());
+        this.inner.as_mut().start_send(msg).map_err(io_err)?;
+        Poll::Ready(Ok(buf.len()))
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        let this = self.project();
+        this.inner.poll_flush(cx).map_err(io_err)
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        let this = self.project();
+        this.inner.poll_close(cx).map_err(io_err)
+    }
+}
+
+fn io_err<E: Into<Box<dyn std::error::Error + Send + Sync>>>(e: E) -> std::io::Error {
+    std::io::Error::other(e.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::{TcpListener, TcpStream};
+    use tokio_tungstenite::{accept_async, client_async};
+
+    /// Spin up a TCP listener, accept one connection, run the WS
+    /// handshake on each side, and return both ends wrapped in
+    /// [`WsByteStream`].
+    async fn ws_pair() -> (
+        WsByteStream<TcpStream>, // client
+        WsByteStream<TcpStream>, // server
+    ) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server_handle = tokio::spawn(async move {
+            let (tcp, _) = listener.accept().await.unwrap();
+            let ws = accept_async(tcp).await.unwrap();
+            WsByteStream::new(ws)
+        });
+        let url = format!("ws://{addr}/ws");
+        let tcp = TcpStream::connect(addr).await.unwrap();
+        let (ws, _resp) = client_async(&url, tcp).await.unwrap();
+        let server = server_handle.await.unwrap();
+        (WsByteStream::new(ws), server)
+    }
+
+    #[tokio::test]
+    async fn small_payload_round_trips_both_directions() {
+        let (mut client, mut server) = ws_pair().await;
+
+        client.write_all(b"hello").await.unwrap();
+        client.flush().await.unwrap();
+        let mut buf = [0u8; 5];
+        server.read_exact(&mut buf).await.unwrap();
+        assert_eq!(&buf, b"hello");
+
+        server.write_all(b"world").await.unwrap();
+        server.flush().await.unwrap();
+        let mut buf = [0u8; 5];
+        client.read_exact(&mut buf).await.unwrap();
+        assert_eq!(&buf, b"world");
+    }
+
+    #[tokio::test]
+    async fn one_megabyte_round_trips() {
+        let (mut client, mut server) = ws_pair().await;
+        let payload: Vec<u8> = (0..1_000_000).map(|i| (i % 251) as u8).collect();
+        let payload_clone = payload.clone();
+
+        let server_task = tokio::spawn(async move {
+            let mut got = vec![0u8; payload_clone.len()];
+            server.read_exact(&mut got).await.unwrap();
+            // echo back to exercise the other direction
+            server.write_all(&got).await.unwrap();
+            server.flush().await.unwrap();
+            got
+        });
+
+        client.write_all(&payload).await.unwrap();
+        client.flush().await.unwrap();
+
+        let mut echoed = vec![0u8; payload.len()];
+        client.read_exact(&mut echoed).await.unwrap();
+        assert_eq!(echoed, payload);
+
+        let received_at_server = server_task.await.unwrap();
+        assert_eq!(received_at_server, payload);
+    }
+
+    #[tokio::test]
+    async fn shutdown_propagates_eof() {
+        let (mut client, mut server) = ws_pair().await;
+
+        // Client closes after writing.
+        client.write_all(b"bye").await.unwrap();
+        client.flush().await.unwrap();
+        client.shutdown().await.unwrap();
+        drop(client);
+
+        // Server reads the bytes, then sees EOF.
+        let mut buf = [0u8; 3];
+        server.read_exact(&mut buf).await.unwrap();
+        assert_eq!(&buf, b"bye");
+        let n = server.read(&mut [0u8; 16]).await.unwrap();
+        assert_eq!(n, 0);
+    }
+}


### PR DESCRIPTION
## Summary

\`src/ws.rs\` wraps a \`tokio_tungstenite::WebSocketStream\` so it implements
\`AsyncRead + AsyncWrite\`. This is the seam that
\`tokio::io::copy_bidirectional\` will use in PR#5 to shovel shadowsocks
payload bytes between the WS layer and the plain TCP socket on the SIP003
side.

## Behavior

- Writes become Binary frames.
- Reads concatenate Binary/Text frame payloads.
- Pings are auto-ponged inside tungstenite.
- A Close frame from the peer surfaces as EOF.

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --all-targets -- -D warnings\`
- [x] \`cargo test --lib\` — 44 passed
- [x] \`small_payload_round_trips_both_directions\`
- [x] \`one_megabyte_round_trips\` — exercises framing under load
- [x] \`shutdown_propagates_eof\` — half-close → 0-byte read on the peer

## Roadmap progress

PR#4 of 9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)