### PR TITLE
v0.1: server + client event loops, SIP003 main.rs, loopback e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,5 +35,5 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: cargo clippy
         run: cargo clippy --all-targets -- -D warnings
-      - name: cargo test --lib
-        run: cargo test --lib
+      - name: cargo test
+        run: cargo test --lib --tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -202,6 +208,8 @@ dependencies = [
  "futures-util",
  "http",
  "http-body-util",
+ "hyper",
+ "hyper-util",
  "libc",
  "pin-project-lite",
  "rcgen",
@@ -211,6 +219,7 @@ dependencies = [
  "tokio-boring",
  "tokio-tungstenite",
  "tracing",
+ "tracing-subscriber",
  "tungstenite",
 ]
 
@@ -295,6 +304,15 @@ checksum = "04412b8935272e3a9bae6f48c7bfff74c2911f60525404edfdd28e49884c3bfb"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
 ]
 
 [[package]]
@@ -429,6 +447,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -460,6 +518,12 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128fmt"
@@ -496,6 +560,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -526,6 +599,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -796,6 +878,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -806,6 +897,12 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
@@ -869,6 +966,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -968,6 +1074,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1017,6 +1153,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,16 @@ bytes = "1"
 futures-util = { version = "0.3", default-features = false, features = ["sink"] }
 http = "1"
 http-body-util = "0.1"
+hyper = { version = "1", features = ["http1", "server"] }
+hyper-util = { version = "0.1", features = ["tokio"] }
 libc = "0.2"
 pin-project-lite = "0.2"
 socket2 = { version = "0.5", features = ["all"] }
-tokio = { version = "1", features = ["net", "rt-multi-thread", "macros", "io-util"] }
+tokio = { version = "1", features = ["net", "rt-multi-thread", "macros", "io-util", "time"] }
 tokio-boring = "4"
 tokio-tungstenite = "0.24"
 tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tungstenite = "0.24"
 
 [dev-dependencies]

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,0 +1,70 @@
+//! Client-side event loop: accept plain TCP from `sslocal`, dial the
+//! upstream over TLS+WS, pipe the payload bytes through.
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use tokio::io::copy_bidirectional;
+use tokio_tungstenite::client_async;
+use tracing::{debug, warn};
+
+use crate::config::ClientCfg;
+use crate::net;
+use crate::tls_client::TlsClient;
+use crate::ws::WsByteStream;
+
+/// Bind, accept, and serve until the listener errors. `listen_addr` is
+/// the loopback bind for `sslocal` (`SS_LOCAL_HOST:SS_LOCAL_PORT`);
+/// `upstream_addr` is the public ssserver/plugin endpoint
+/// (`SS_REMOTE_HOST:SS_REMOTE_PORT`).
+pub async fn run(listen_addr: &str, upstream_addr: &str, cfg: ClientCfg) -> Result<()> {
+    let tls = Arc::new(TlsClient::build(&cfg)?);
+    let listener = net::create_listener(listen_addr, cfg.fast_open).await?;
+    let cfg = Arc::new(cfg);
+    let upstream = Arc::<str>::from(upstream_addr);
+
+    tracing::info!("listening on {listen_addr}");
+    loop {
+        let (mut tcp_in, peer) = match listener.accept().await {
+            Ok(v) => v,
+            Err(e) => {
+                warn!("accept error: {e:#}");
+                continue;
+            }
+        };
+        let tls = tls.clone();
+        let cfg = cfg.clone();
+        let upstream = upstream.clone();
+
+        tokio::spawn(async move {
+            let tcp_up = match net::connect(&upstream, cfg.fast_open).await {
+                Ok(s) => s,
+                Err(e) => {
+                    warn!("{peer}: dial {upstream}: {e:#}");
+                    return;
+                }
+            };
+            let tls_up = match tls.connect(&cfg.sni, tcp_up).await {
+                Ok(s) => s,
+                Err(e) => {
+                    warn!("{peer}: tls handshake: {e:#}");
+                    return;
+                }
+            };
+
+            let url = format!("wss://{}{}", cfg.sni, cfg.ws_path);
+            let (ws, _resp) = match client_async(url, tls_up).await {
+                Ok(v) => v,
+                Err(e) => {
+                    warn!("{peer}: ws upgrade: {e:#}");
+                    return;
+                }
+            };
+            let mut wsbs = WsByteStream::new(ws);
+
+            if let Err(e) = copy_bidirectional(&mut tcp_in, &mut wsbs).await {
+                debug!("{peer}: bidi-copy ended: {e:#}");
+            }
+        });
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,10 @@
 //! See `docs/PRD.md` for the high-level design and `docs/ROADMAP.md` for
 //! the milestone breakdown.
 
+pub mod client;
 pub mod config;
 pub mod net;
+pub mod server;
 pub mod sip003;
 pub mod stealth;
 pub mod tls_client;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,33 @@
-fn main() {
-    eprintln!("ech-tls-tunnel: not yet implemented (see docs/ROADMAP.md)");
-    std::process::exit(1);
+use anyhow::Result;
+use ech_tls_tunnel::config::Config;
+use ech_tls_tunnel::sip003::SipEnv;
+use ech_tls_tunnel::{client, server};
+use tracing::error;
+
+fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()),
+        )
+        .init();
+
+    let sip = SipEnv::from_env()?;
+    let mode = sip.options.mode()?;
+    let cfg = Config::from_options(&sip.options)?;
+    let (listen, upstream) = sip.endpoints(mode);
+
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?;
+
+    rt.block_on(async move {
+        let result = match cfg {
+            Config::Server(s) => server::run(&listen, &upstream, s).await,
+            Config::Client(c) => client::run(&listen, &upstream, c).await,
+        };
+        if let Err(e) = &result {
+            error!("plugin exited: {e:#}");
+        }
+        result
+    })
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,0 +1,149 @@
+//! Server-side event loop: terminate TLS, accept WebSocket Upgrade on
+//! the secret path, and pipe the payload bytes to the loopback
+//! `ssserver`.
+
+use std::convert::Infallible;
+use std::sync::Arc;
+
+use anyhow::Result;
+use bytes::Bytes;
+use http::{header, HeaderValue, Method, Request, Response, StatusCode};
+use http_body_util::Full;
+use hyper::body::Incoming;
+use hyper::service::service_fn;
+use hyper_util::rt::TokioIo;
+use tokio::io::copy_bidirectional;
+use tokio_tungstenite::tungstenite::handshake::derive_accept_key;
+use tokio_tungstenite::tungstenite::protocol::Role;
+use tokio_tungstenite::WebSocketStream;
+use tracing::{debug, warn};
+
+use crate::config::ServerCfg;
+use crate::net;
+use crate::stealth;
+use crate::tls_server::TlsServer;
+use crate::ws::WsByteStream;
+
+/// Bind, accept, and serve until the listener errors. `listen_addr` is
+/// the public bind address (server-side: `SS_REMOTE_HOST:SS_REMOTE_PORT`),
+/// `upstream_addr` is the loopback `ssserver` listener
+/// (`SS_LOCAL_HOST:SS_LOCAL_PORT`).
+pub async fn run(listen_addr: &str, upstream_addr: &str, cfg: ServerCfg) -> Result<()> {
+    let tls = Arc::new(TlsServer::build_static(&cfg)?);
+    let listener = net::create_listener(listen_addr, cfg.fast_open).await?;
+    let cfg = Arc::new(cfg);
+    let upstream = Arc::<str>::from(upstream_addr);
+
+    tracing::info!("listening on {listen_addr}");
+    loop {
+        let (tcp, peer) = match listener.accept().await {
+            Ok(v) => v,
+            Err(e) => {
+                warn!("accept error: {e:#}");
+                continue;
+            }
+        };
+        let tls = tls.clone();
+        let cfg = cfg.clone();
+        let upstream = upstream.clone();
+
+        tokio::spawn(async move {
+            let stream = match tls.accept(tcp).await {
+                Ok(s) => s,
+                Err(e) => {
+                    debug!("{peer}: tls handshake: {e:#}");
+                    return;
+                }
+            };
+            let io = TokioIo::new(stream);
+            let svc = service_fn(move |req| {
+                let cfg = cfg.clone();
+                let upstream = upstream.clone();
+                async move { handle_request(req, cfg, upstream).await }
+            });
+            if let Err(e) = hyper::server::conn::http1::Builder::new()
+                .serve_connection(io, svc)
+                .with_upgrades()
+                .await
+            {
+                debug!("{peer}: http: {e:#}");
+            }
+        });
+    }
+}
+
+async fn handle_request(
+    mut req: Request<Incoming>,
+    cfg: Arc<ServerCfg>,
+    upstream: Arc<str>,
+) -> Result<Response<Full<Bytes>>, Infallible> {
+    if req.method() != Method::GET || req.uri().path() != cfg.ws_path || !is_ws_upgrade(&req) {
+        return Ok(stealth::fake_404(&cfg.server_name));
+    }
+
+    let key = match req.headers().get(header::SEC_WEBSOCKET_KEY) {
+        Some(k) => k.clone(),
+        None => return Ok(stealth::fake_404(&cfg.server_name)),
+    };
+
+    let accept_value = match HeaderValue::from_str(&derive_accept_key(key.as_bytes())) {
+        Ok(v) => v,
+        Err(_) => return Ok(stealth::fake_404(&cfg.server_name)),
+    };
+
+    // Capture the upgrade future *before* the spawn / before `req` drops —
+    // this is the canonical hyper 1.x pattern (matches hyper-tungstenite).
+    let on_upgrade = hyper::upgrade::on(&mut req);
+    let fast_open = cfg.fast_open;
+    tokio::spawn(async move {
+        let upgraded = match on_upgrade.await {
+            Ok(u) => u,
+            Err(e) => {
+                warn!("upgrade failed: {e:#}");
+                return;
+            }
+        };
+        let io = TokioIo::new(upgraded);
+        let ws = WebSocketStream::from_raw_socket(io, Role::Server, None).await;
+        let mut wsbs = WsByteStream::new(ws);
+
+        let mut up = match net::connect(&upstream, fast_open).await {
+            Ok(s) => s,
+            Err(e) => {
+                warn!("dial upstream {upstream}: {e:#}");
+                return;
+            }
+        };
+
+        if let Err(e) = copy_bidirectional(&mut wsbs, &mut up).await {
+            debug!("bidi-copy ended: {e:#}");
+        }
+    });
+
+    Ok(Response::builder()
+        .status(StatusCode::SWITCHING_PROTOCOLS)
+        .header(header::UPGRADE, "websocket")
+        .header(header::CONNECTION, "Upgrade")
+        .header(header::SEC_WEBSOCKET_ACCEPT, accept_value)
+        .body(Full::new(Bytes::new()))
+        .expect("static 101 response is valid"))
+}
+
+fn is_ws_upgrade(req: &Request<Incoming>) -> bool {
+    let upgrade_match = req
+        .headers()
+        .get(header::UPGRADE)
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|v| v.eq_ignore_ascii_case("websocket"));
+
+    let connection_match = req
+        .headers()
+        .get(header::CONNECTION)
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|v| {
+            v.split(',')
+                .any(|p| p.trim().eq_ignore_ascii_case("upgrade"))
+        });
+
+    upgrade_match && connection_match
+}

--- a/tests/loops_e2e.rs
+++ b/tests/loops_e2e.rs
@@ -1,0 +1,188 @@
+//! Loopback end-to-end test for `server::run` + `client::run`.
+//!
+//! Wires up the server and client event loops on `127.0.0.1` with a
+//! self-signed cert, then verifies bytes round-trip from a "fake
+//! sslocal" → client loop → TLS+WS → server loop → "fake ssserver".
+//! No external binaries — `tests/sip003_e2e.rs` (PR#6) is the version
+//! that drives the real `shadowsocks-rust` ssserver/sslocal.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use ech_tls_tunnel::client;
+use ech_tls_tunnel::config::{ClientCfg, ClientTrust, ServerCfg, ServerTls};
+use ech_tls_tunnel::server;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+
+fn pick_port() -> u16 {
+    let l = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    l.local_addr().unwrap().port()
+}
+
+async fn wait_for_ready(addr: &str) {
+    for _ in 0..40 {
+        if TcpStream::connect(addr).await.is_ok() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    panic!("server at {addr} did not become ready");
+}
+
+fn write_pems(dir: &std::path::Path, cert_pem: &str, key_pem: &str) -> (PathBuf, PathBuf) {
+    let cert = dir.join("cert.pem");
+    let key = dir.join("key.pem");
+    std::fs::write(&cert, cert_pem).unwrap();
+    std::fs::write(&key, key_pem).unwrap();
+    (cert, key)
+}
+
+#[tokio::test]
+async fn full_loop_round_trips_payload() {
+    // ── 1. echo server (stand-in for ssserver) ────────────────────────
+    let echo = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let echo_addr = echo.local_addr().unwrap();
+    tokio::spawn(async move {
+        loop {
+            let (mut sock, _) = echo.accept().await.unwrap();
+            tokio::spawn(async move {
+                let mut buf = vec![0u8; 4096];
+                while let Ok(n) = sock.read(&mut buf).await {
+                    if n == 0 {
+                        break;
+                    }
+                    if sock.write_all(&buf[..n]).await.is_err() {
+                        break;
+                    }
+                }
+            });
+        }
+    });
+
+    // ── 2. self-signed cert ───────────────────────────────────────────
+    let kp = rcgen::generate_simple_self_signed(vec!["tunnel.local".into()]).unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    let (cert_path, key_path) =
+        write_pems(dir.path(), &kp.cert.pem(), &kp.key_pair.serialize_pem());
+
+    // ── 3. server loop on the public-side port ────────────────────────
+    let tunnel_port = pick_port();
+    let tunnel_addr = format!("127.0.0.1:{tunnel_port}");
+    let server_cfg = ServerCfg {
+        domain: "tunnel.local".into(),
+        ws_path: "/ws-test".into(),
+        fast_open: false,
+        tls: ServerTls::Static {
+            cert_file: cert_path.clone(),
+            key_file: key_path,
+        },
+        ech: None,
+        server_name: "nginx/1.24.0".into(),
+    };
+    let server_listen = tunnel_addr.clone();
+    let echo_str = echo_addr.to_string();
+    tokio::spawn(async move {
+        let _ = server::run(&server_listen, &echo_str, server_cfg).await;
+    });
+    wait_for_ready(&tunnel_addr).await;
+
+    // ── 4. client loop on the loopback-side port ──────────────────────
+    let local_port = pick_port();
+    let local_addr = format!("127.0.0.1:{local_port}");
+    let client_cfg = ClientCfg {
+        sni: "tunnel.local".into(),
+        ws_path: "/ws-test".into(),
+        fast_open: false,
+        ech: None,
+        trust: ClientTrust::CaFile(cert_path),
+    };
+    let client_listen = local_addr.clone();
+    let client_upstream = tunnel_addr.clone();
+    tokio::spawn(async move {
+        let _ = client::run(&client_listen, &client_upstream, client_cfg).await;
+    });
+    wait_for_ready(&local_addr).await;
+
+    // ── 5. drive: simulate sslocal opening a connection through us ────
+    let mut sock = TcpStream::connect(&local_addr).await.unwrap();
+    sock.write_all(b"ping").await.unwrap();
+    sock.flush().await.unwrap();
+    let mut buf = [0u8; 4];
+    sock.read_exact(&mut buf).await.unwrap();
+    assert_eq!(&buf, b"ping");
+
+    // larger payload to stress framing
+    let big: Vec<u8> = (0..256_000).map(|i| (i % 251) as u8).collect();
+    sock.write_all(&big).await.unwrap();
+    sock.flush().await.unwrap();
+    let mut got = vec![0u8; big.len()];
+    sock.read_exact(&mut got).await.unwrap();
+    assert_eq!(got, big);
+}
+
+#[tokio::test]
+async fn unmatched_path_serves_fake_404() {
+    // Stand-up a server (no real upstream needed for this test).
+    let kp = rcgen::generate_simple_self_signed(vec!["tunnel.local".into()]).unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    let (cert_path, key_path) =
+        write_pems(dir.path(), &kp.cert.pem(), &kp.key_pair.serialize_pem());
+
+    let tunnel_port = pick_port();
+    let tunnel_addr = format!("127.0.0.1:{tunnel_port}");
+    let server_cfg = ServerCfg {
+        domain: "tunnel.local".into(),
+        ws_path: "/ws-secret".into(),
+        fast_open: false,
+        tls: ServerTls::Static {
+            cert_file: cert_path.clone(),
+            key_file: key_path,
+        },
+        ech: None,
+        server_name: "nginx/1.24.0".into(),
+    };
+    let listen = tunnel_addr.clone();
+    tokio::spawn(async move {
+        // upstream addr is irrelevant — we never hit the upgrade path
+        let _ = server::run(&listen, "127.0.0.1:1", server_cfg).await;
+    });
+    wait_for_ready(&tunnel_addr).await;
+
+    // Probe the wrong path with curl-equivalent (boring TLS client +
+    // raw HTTP/1 request). Expect 404 with the fake nginx Server header.
+    use boring::ssl::{SslConnector, SslMethod, SslVerifyMode};
+    use boring::x509::X509;
+
+    let mut cb = SslConnector::builder(SslMethod::tls_client()).unwrap();
+    cb.cert_store_mut()
+        .add_cert(X509::from_pem(kp.cert.pem().as_bytes()).unwrap())
+        .unwrap();
+    cb.set_verify(SslVerifyMode::PEER);
+    let connector = cb.build();
+
+    let tcp = TcpStream::connect(&tunnel_addr).await.unwrap();
+    let mut tls = tokio_boring::connect(connector.configure().unwrap(), "tunnel.local", tcp)
+        .await
+        .unwrap();
+
+    tls.write_all(b"GET / HTTP/1.1\r\nHost: tunnel.local\r\n\r\n")
+        .await
+        .unwrap();
+    tls.flush().await.unwrap();
+
+    let mut buf = vec![0u8; 1024];
+    let n = tls.read(&mut buf).await.unwrap();
+    let resp = std::str::from_utf8(&buf[..n]).unwrap();
+    assert!(
+        resp.starts_with("HTTP/1.1 404"),
+        "expected 404, got: {resp}"
+    );
+    // Hyper lowercases header names on the wire (HTTP/1.1 spec is
+    // case-insensitive). Match that.
+    let lc = resp.to_ascii_lowercase();
+    assert!(
+        lc.contains("server: nginx/1.24.0"),
+        "expected fake nginx Server header, got: {resp}"
+    );
+}


### PR DESCRIPTION
## Summary

The pieces snap together. PR#5 adds:

- **\`src/server.rs\`** — public listener → BoringSSL accept → hyper http1
  with upgrades. WS Upgrade on \`cfg.ws_path\` returns 101 + bidi-copy
  to the loopback ssserver. Anything else gets the fake nginx 404.
- **\`src/client.rs\`** — loopback listener for sslocal → dial upstream
  → TLS handshake → WebSocket handshake (\`wss://<sni>/<ws_path>\`) →
  bidi-copy.
- **\`src/main.rs\`** — reads \`SS_*\` env, builds \`Config\` from
  \`SS_PLUGIN_OPTIONS\`, dispatches to the right loop.
- **\`tests/loops_e2e.rs\`** — full loopback test with self-signed
  rcgen cert: bytes round-trip from a "fake sslocal" through both
  loops to a "fake ssserver" and back, both small and 256 kB
  payloads. A second test probes the wrong path and asserts the fake
  nginx 404.

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --all-targets -- -D warnings\`
- [x] \`cargo test --lib --tests\` — 46 passed (44 lib + 2 integration)

CI now runs \`cargo test --lib --tests\` (was \`--lib\` only) so the new
integration tests gate every PR.

## Implementation notes

- \`tokio_tungstenite::client_async\` builds the proper
  Sec-WebSocket-Key / -Version when given a URI string; passing a
  hand-built \`Request<()>\` without those headers fails with
  "Missing... sec-websocket-key" — using the URL form is the right
  pattern.
- Server-side upgrade uses the canonical \`hyper::upgrade::on(&mut req)\`
  pattern (capture the \`OnUpgrade\` future before the spawn) — matches
  hyper-tungstenite's upstream reference.

## Roadmap progress

PR#5 of 9. The next PR is the real shadowsocks-rust e2e test using
\`ssserver\`/\`sslocal\`/\`curl\` subprocesses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)