### PR TITLE
v0.1: SIP003 e2e test with shadowsocks-rust + curl + 10min timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,22 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
+      - name: Install shadowsocks-rust (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          set -euo pipefail
+          VER="v1.21.2"
+          curl -fsSL "https://github.com/shadowsocks/shadowsocks-rust/releases/download/${VER}/shadowsocks-${VER}.x86_64-unknown-linux-gnu.tar.xz" \
+            | tar -xJ
+          sudo mv ssserver sslocal /usr/local/bin/
+          ssserver --version
+          sslocal --version
+      - name: Install shadowsocks-rust (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          brew install shadowsocks-rust
+          ssserver --version
+          sslocal --version
       - name: cargo clippy
         run: cargo clippy --all-targets -- -D warnings
       - name: cargo test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,6 +221,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tungstenite",
+ "which",
 ]
 
 [[package]]
@@ -408,6 +409,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -546,6 +556,12 @@ dependencies = [
  "cfg-if",
  "windows-link",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -792,6 +808,19 @@ checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -799,7 +828,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -944,7 +973,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -1225,6 +1254,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "6.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f"
+dependencies = [
+ "either",
+ "home",
+ "rustix 0.38.44",
+ "winsafe",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1333,6 +1374,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ tungstenite = "0.24"
 rcgen = "0.13"
 tempfile = "3"
 tokio = { version = "1", features = ["net", "rt-multi-thread", "macros", "io-util", "time"] }
+which = "6"
 
 [profile.release]
 strip = true

--- a/tests/loops_e2e.rs
+++ b/tests/loops_e2e.rs
@@ -15,6 +15,18 @@ use ech_tls_tunnel::server;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 
+/// Hard deadline for every test in this file.
+const TEST_TIMEOUT: Duration = Duration::from_secs(600);
+
+async fn within_deadline<F, T>(label: &'static str, fut: F) -> T
+where
+    F: std::future::Future<Output = T>,
+{
+    tokio::time::timeout(TEST_TIMEOUT, fut)
+        .await
+        .unwrap_or_else(|_| panic!("{label} timed out after {:?}", TEST_TIMEOUT))
+}
+
 fn pick_port() -> u16 {
     let l = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
     l.local_addr().unwrap().port()
@@ -40,149 +52,155 @@ fn write_pems(dir: &std::path::Path, cert_pem: &str, key_pem: &str) -> (PathBuf,
 
 #[tokio::test]
 async fn full_loop_round_trips_payload() {
-    // ── 1. echo server (stand-in for ssserver) ────────────────────────
-    let echo = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let echo_addr = echo.local_addr().unwrap();
-    tokio::spawn(async move {
-        loop {
-            let (mut sock, _) = echo.accept().await.unwrap();
-            tokio::spawn(async move {
-                let mut buf = vec![0u8; 4096];
-                while let Ok(n) = sock.read(&mut buf).await {
-                    if n == 0 {
-                        break;
+    within_deadline("full_loop_round_trips_payload", async {
+        // ── 1. echo server (stand-in for ssserver) ────────────────────────
+        let echo = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let echo_addr = echo.local_addr().unwrap();
+        tokio::spawn(async move {
+            loop {
+                let (mut sock, _) = echo.accept().await.unwrap();
+                tokio::spawn(async move {
+                    let mut buf = vec![0u8; 4096];
+                    while let Ok(n) = sock.read(&mut buf).await {
+                        if n == 0 {
+                            break;
+                        }
+                        if sock.write_all(&buf[..n]).await.is_err() {
+                            break;
+                        }
                     }
-                    if sock.write_all(&buf[..n]).await.is_err() {
-                        break;
-                    }
-                }
-            });
-        }
-    });
+                });
+            }
+        });
 
-    // ── 2. self-signed cert ───────────────────────────────────────────
-    let kp = rcgen::generate_simple_self_signed(vec!["tunnel.local".into()]).unwrap();
-    let dir = tempfile::tempdir().unwrap();
-    let (cert_path, key_path) =
-        write_pems(dir.path(), &kp.cert.pem(), &kp.key_pair.serialize_pem());
+        // ── 2. self-signed cert ───────────────────────────────────────────
+        let kp = rcgen::generate_simple_self_signed(vec!["tunnel.local".into()]).unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let (cert_path, key_path) =
+            write_pems(dir.path(), &kp.cert.pem(), &kp.key_pair.serialize_pem());
 
-    // ── 3. server loop on the public-side port ────────────────────────
-    let tunnel_port = pick_port();
-    let tunnel_addr = format!("127.0.0.1:{tunnel_port}");
-    let server_cfg = ServerCfg {
-        domain: "tunnel.local".into(),
-        ws_path: "/ws-test".into(),
-        fast_open: false,
-        tls: ServerTls::Static {
-            cert_file: cert_path.clone(),
-            key_file: key_path,
-        },
-        ech: None,
-        server_name: "nginx/1.24.0".into(),
-    };
-    let server_listen = tunnel_addr.clone();
-    let echo_str = echo_addr.to_string();
-    tokio::spawn(async move {
-        let _ = server::run(&server_listen, &echo_str, server_cfg).await;
-    });
-    wait_for_ready(&tunnel_addr).await;
+        // ── 3. server loop on the public-side port ────────────────────────
+        let tunnel_port = pick_port();
+        let tunnel_addr = format!("127.0.0.1:{tunnel_port}");
+        let server_cfg = ServerCfg {
+            domain: "tunnel.local".into(),
+            ws_path: "/ws-test".into(),
+            fast_open: false,
+            tls: ServerTls::Static {
+                cert_file: cert_path.clone(),
+                key_file: key_path,
+            },
+            ech: None,
+            server_name: "nginx/1.24.0".into(),
+        };
+        let server_listen = tunnel_addr.clone();
+        let echo_str = echo_addr.to_string();
+        tokio::spawn(async move {
+            let _ = server::run(&server_listen, &echo_str, server_cfg).await;
+        });
+        wait_for_ready(&tunnel_addr).await;
 
-    // ── 4. client loop on the loopback-side port ──────────────────────
-    let local_port = pick_port();
-    let local_addr = format!("127.0.0.1:{local_port}");
-    let client_cfg = ClientCfg {
-        sni: "tunnel.local".into(),
-        ws_path: "/ws-test".into(),
-        fast_open: false,
-        ech: None,
-        trust: ClientTrust::CaFile(cert_path),
-    };
-    let client_listen = local_addr.clone();
-    let client_upstream = tunnel_addr.clone();
-    tokio::spawn(async move {
-        let _ = client::run(&client_listen, &client_upstream, client_cfg).await;
-    });
-    wait_for_ready(&local_addr).await;
+        // ── 4. client loop on the loopback-side port ──────────────────────
+        let local_port = pick_port();
+        let local_addr = format!("127.0.0.1:{local_port}");
+        let client_cfg = ClientCfg {
+            sni: "tunnel.local".into(),
+            ws_path: "/ws-test".into(),
+            fast_open: false,
+            ech: None,
+            trust: ClientTrust::CaFile(cert_path),
+        };
+        let client_listen = local_addr.clone();
+        let client_upstream = tunnel_addr.clone();
+        tokio::spawn(async move {
+            let _ = client::run(&client_listen, &client_upstream, client_cfg).await;
+        });
+        wait_for_ready(&local_addr).await;
 
-    // ── 5. drive: simulate sslocal opening a connection through us ────
-    let mut sock = TcpStream::connect(&local_addr).await.unwrap();
-    sock.write_all(b"ping").await.unwrap();
-    sock.flush().await.unwrap();
-    let mut buf = [0u8; 4];
-    sock.read_exact(&mut buf).await.unwrap();
-    assert_eq!(&buf, b"ping");
+        // ── 5. drive: simulate sslocal opening a connection through us ────
+        let mut sock = TcpStream::connect(&local_addr).await.unwrap();
+        sock.write_all(b"ping").await.unwrap();
+        sock.flush().await.unwrap();
+        let mut buf = [0u8; 4];
+        sock.read_exact(&mut buf).await.unwrap();
+        assert_eq!(&buf, b"ping");
 
-    // larger payload to stress framing
-    let big: Vec<u8> = (0..256_000).map(|i| (i % 251) as u8).collect();
-    sock.write_all(&big).await.unwrap();
-    sock.flush().await.unwrap();
-    let mut got = vec![0u8; big.len()];
-    sock.read_exact(&mut got).await.unwrap();
-    assert_eq!(got, big);
+        // larger payload to stress framing
+        let big: Vec<u8> = (0..256_000).map(|i| (i % 251) as u8).collect();
+        sock.write_all(&big).await.unwrap();
+        sock.flush().await.unwrap();
+        let mut got = vec![0u8; big.len()];
+        sock.read_exact(&mut got).await.unwrap();
+        assert_eq!(got, big);
+    })
+    .await
 }
 
 #[tokio::test]
 async fn unmatched_path_serves_fake_404() {
-    // Stand-up a server (no real upstream needed for this test).
-    let kp = rcgen::generate_simple_self_signed(vec!["tunnel.local".into()]).unwrap();
-    let dir = tempfile::tempdir().unwrap();
-    let (cert_path, key_path) =
-        write_pems(dir.path(), &kp.cert.pem(), &kp.key_pair.serialize_pem());
+    within_deadline("unmatched_path_serves_fake_404", async {
+        // Stand-up a server (no real upstream needed for this test).
+        let kp = rcgen::generate_simple_self_signed(vec!["tunnel.local".into()]).unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let (cert_path, key_path) =
+            write_pems(dir.path(), &kp.cert.pem(), &kp.key_pair.serialize_pem());
 
-    let tunnel_port = pick_port();
-    let tunnel_addr = format!("127.0.0.1:{tunnel_port}");
-    let server_cfg = ServerCfg {
-        domain: "tunnel.local".into(),
-        ws_path: "/ws-secret".into(),
-        fast_open: false,
-        tls: ServerTls::Static {
-            cert_file: cert_path.clone(),
-            key_file: key_path,
-        },
-        ech: None,
-        server_name: "nginx/1.24.0".into(),
-    };
-    let listen = tunnel_addr.clone();
-    tokio::spawn(async move {
-        // upstream addr is irrelevant — we never hit the upgrade path
-        let _ = server::run(&listen, "127.0.0.1:1", server_cfg).await;
-    });
-    wait_for_ready(&tunnel_addr).await;
+        let tunnel_port = pick_port();
+        let tunnel_addr = format!("127.0.0.1:{tunnel_port}");
+        let server_cfg = ServerCfg {
+            domain: "tunnel.local".into(),
+            ws_path: "/ws-secret".into(),
+            fast_open: false,
+            tls: ServerTls::Static {
+                cert_file: cert_path.clone(),
+                key_file: key_path,
+            },
+            ech: None,
+            server_name: "nginx/1.24.0".into(),
+        };
+        let listen = tunnel_addr.clone();
+        tokio::spawn(async move {
+            // upstream addr is irrelevant — we never hit the upgrade path
+            let _ = server::run(&listen, "127.0.0.1:1", server_cfg).await;
+        });
+        wait_for_ready(&tunnel_addr).await;
 
-    // Probe the wrong path with curl-equivalent (boring TLS client +
-    // raw HTTP/1 request). Expect 404 with the fake nginx Server header.
-    use boring::ssl::{SslConnector, SslMethod, SslVerifyMode};
-    use boring::x509::X509;
+        // Probe the wrong path with curl-equivalent (boring TLS client +
+        // raw HTTP/1 request). Expect 404 with the fake nginx Server header.
+        use boring::ssl::{SslConnector, SslMethod, SslVerifyMode};
+        use boring::x509::X509;
 
-    let mut cb = SslConnector::builder(SslMethod::tls_client()).unwrap();
-    cb.cert_store_mut()
-        .add_cert(X509::from_pem(kp.cert.pem().as_bytes()).unwrap())
-        .unwrap();
-    cb.set_verify(SslVerifyMode::PEER);
-    let connector = cb.build();
+        let mut cb = SslConnector::builder(SslMethod::tls_client()).unwrap();
+        cb.cert_store_mut()
+            .add_cert(X509::from_pem(kp.cert.pem().as_bytes()).unwrap())
+            .unwrap();
+        cb.set_verify(SslVerifyMode::PEER);
+        let connector = cb.build();
 
-    let tcp = TcpStream::connect(&tunnel_addr).await.unwrap();
-    let mut tls = tokio_boring::connect(connector.configure().unwrap(), "tunnel.local", tcp)
-        .await
-        .unwrap();
+        let tcp = TcpStream::connect(&tunnel_addr).await.unwrap();
+        let mut tls = tokio_boring::connect(connector.configure().unwrap(), "tunnel.local", tcp)
+            .await
+            .unwrap();
 
-    tls.write_all(b"GET / HTTP/1.1\r\nHost: tunnel.local\r\n\r\n")
-        .await
-        .unwrap();
-    tls.flush().await.unwrap();
+        tls.write_all(b"GET / HTTP/1.1\r\nHost: tunnel.local\r\n\r\n")
+            .await
+            .unwrap();
+        tls.flush().await.unwrap();
 
-    let mut buf = vec![0u8; 1024];
-    let n = tls.read(&mut buf).await.unwrap();
-    let resp = std::str::from_utf8(&buf[..n]).unwrap();
-    assert!(
-        resp.starts_with("HTTP/1.1 404"),
-        "expected 404, got: {resp}"
-    );
-    // Hyper lowercases header names on the wire (HTTP/1.1 spec is
-    // case-insensitive). Match that.
-    let lc = resp.to_ascii_lowercase();
-    assert!(
-        lc.contains("server: nginx/1.24.0"),
-        "expected fake nginx Server header, got: {resp}"
-    );
+        let mut buf = vec![0u8; 1024];
+        let n = tls.read(&mut buf).await.unwrap();
+        let resp = std::str::from_utf8(&buf[..n]).unwrap();
+        assert!(
+            resp.starts_with("HTTP/1.1 404"),
+            "expected 404, got: {resp}"
+        );
+        // Hyper lowercases header names on the wire (HTTP/1.1 spec is
+        // case-insensitive). Match that.
+        let lc = resp.to_ascii_lowercase();
+        assert!(
+            lc.contains("server: nginx/1.24.0"),
+            "expected fake nginx Server header, got: {resp}"
+        );
+    })
+    .await
 }

--- a/tests/sip003_e2e.rs
+++ b/tests/sip003_e2e.rs
@@ -1,0 +1,224 @@
+//! Full SIP003 end-to-end test against shadowsocks-rust.
+//!
+//! Spawns `ssserver` and `sslocal` (from the `shadowsocks-rust`
+//! distribution) as subprocesses, each with our plugin binary attached
+//! via `--plugin`. Drives traffic with `curl --socks5-hostname` against
+//! an in-process echo HTTP server. Self-signed cert, all on
+//! `127.0.0.1`.
+//!
+//! Skips cleanly with a clear message if `ssserver`, `sslocal`, or
+//! `curl` aren't on `PATH`.
+
+use std::path::PathBuf;
+use std::process::{Child, Command};
+use std::time::Duration;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+
+/// Hard deadline for the e2e test.
+const TEST_TIMEOUT: Duration = Duration::from_secs(600);
+
+fn pick_port() -> u16 {
+    let l = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    l.local_addr().unwrap().port()
+}
+
+fn precondition() -> Option<String> {
+    for tool in ["ssserver", "sslocal", "curl"] {
+        if which::which(tool).is_err() {
+            return Some(format!(
+                "{tool} not on PATH; install shadowsocks-rust + curl to run this test"
+            ));
+        }
+    }
+    None
+}
+
+async fn wait_for_ready(addr: &str) {
+    for _ in 0..80 {
+        if TcpStream::connect(addr).await.is_ok() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    panic!("listener at {addr} did not become ready");
+}
+
+/// Tiny HTTP/1.1 echo server: responds `200 OK` with body `echo:<path>`.
+async fn spawn_echo_server() -> std::net::SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        loop {
+            let (mut sock, _) = match listener.accept().await {
+                Ok(v) => v,
+                Err(_) => continue,
+            };
+            tokio::spawn(async move {
+                let mut buf = vec![0u8; 4096];
+                let n = sock.read(&mut buf).await.unwrap_or(0);
+                let head = std::str::from_utf8(&buf[..n]).unwrap_or("");
+                let path = head
+                    .lines()
+                    .next()
+                    .and_then(|l| l.split_whitespace().nth(1))
+                    .unwrap_or("/")
+                    .to_string();
+                let body = format!("echo:{path}");
+                let resp = format!(
+                    "HTTP/1.1 200 OK\r\n\
+                     Content-Type: text/plain\r\n\
+                     Content-Length: {}\r\n\
+                     Connection: close\r\n\
+                     \r\n\
+                     {}",
+                    body.len(),
+                    body
+                );
+                let _ = sock.write_all(resp.as_bytes()).await;
+                let _ = sock.shutdown().await;
+            });
+        }
+    });
+    addr
+}
+
+struct ChildGuard(Option<Child>);
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        if let Some(mut c) = self.0.take() {
+            let _ = c.kill();
+            let _ = c.wait();
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn sip003_full_pipeline_with_shadowsocks_rust() {
+    tokio::time::timeout(
+        TEST_TIMEOUT,
+        sip003_full_pipeline_with_shadowsocks_rust_inner(),
+    )
+    .await
+    .expect("sip003_e2e timed out after 10 minutes");
+}
+
+async fn sip003_full_pipeline_with_shadowsocks_rust_inner() {
+    if let Some(reason) = precondition() {
+        eprintln!("SKIP sip003_e2e: {reason}");
+        return;
+    }
+
+    // The plugin binary built by `cargo test` (cargo sets this env var
+    // for integration tests so we don't have to re-invoke cargo).
+    let plugin_path: PathBuf = env!("CARGO_BIN_EXE_ech-tls-tunnel").into();
+    assert!(
+        plugin_path.exists(),
+        "plugin binary missing at {}",
+        plugin_path.display()
+    );
+
+    // ── self-signed cert ──────────────────────────────────────────────
+    let kp = rcgen::generate_simple_self_signed(vec!["tunnel.local".into()]).unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    let cert_path = dir.path().join("cert.pem");
+    let key_path = dir.path().join("key.pem");
+    std::fs::write(&cert_path, kp.cert.pem()).unwrap();
+    std::fs::write(&key_path, kp.key_pair.serialize_pem()).unwrap();
+
+    // ── echo server (the "destination" for curl traffic) ─────────────
+    let echo_addr = spawn_echo_server().await;
+
+    // ── ports for the public tunnel and the local SOCKS5 ─────────────
+    let tunnel_port = pick_port();
+    let local_port = pick_port();
+
+    // ── ssserver + plugin ────────────────────────────────────────────
+    let ssserver_opts = format!(
+        "mode=server;domain=tunnel.local;path=/ws-test;cert={};key={}",
+        cert_path.display(),
+        key_path.display()
+    );
+    let _ssserver = ChildGuard(Some(
+        Command::new("ssserver")
+            .args([
+                "-s",
+                &format!("127.0.0.1:{tunnel_port}"),
+                "-k",
+                "testpass-12345",
+                "-m",
+                "aes-128-gcm",
+                "--plugin",
+                plugin_path.to_str().unwrap(),
+                "--plugin-opts",
+                &ssserver_opts,
+            ])
+            .spawn()
+            .expect("spawn ssserver"),
+    ));
+
+    wait_for_ready(&format!("127.0.0.1:{tunnel_port}")).await;
+
+    // ── sslocal + plugin ─────────────────────────────────────────────
+    let sslocal_opts = format!(
+        "mode=client;sni=tunnel.local;path=/ws-test;ca_file={}",
+        cert_path.display()
+    );
+    let _sslocal = ChildGuard(Some(
+        Command::new("sslocal")
+            .args([
+                "-b",
+                &format!("127.0.0.1:{local_port}"),
+                "-s",
+                &format!("127.0.0.1:{tunnel_port}"),
+                "-k",
+                "testpass-12345",
+                "-m",
+                "aes-128-gcm",
+                "--protocol",
+                "socks",
+                "--plugin",
+                plugin_path.to_str().unwrap(),
+                "--plugin-opts",
+                &sslocal_opts,
+            ])
+            .spawn()
+            .expect("spawn sslocal"),
+    ));
+
+    wait_for_ready(&format!("127.0.0.1:{local_port}")).await;
+    // sslocal sometimes accepts on its SOCKS port a beat before the
+    // plugin upstream listener is ready; small extra grace.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // ── drive traffic with curl through the SOCKS5 entrypoint ────────
+    let url = format!("http://{}/hello", echo_addr);
+    let out = Command::new("curl")
+        .args([
+            "--silent",
+            "--show-error",
+            "--max-time",
+            "15",
+            "--socks5-hostname",
+            &format!("127.0.0.1:{local_port}"),
+            &url,
+        ])
+        .output()
+        .expect("run curl");
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "curl failed: status={:?}\nstdout: {}\nstderr: {}",
+        out.status,
+        stdout,
+        stderr
+    );
+    assert_eq!(
+        stdout.trim(),
+        "echo:/hello",
+        "unexpected response body: stdout={stdout:?} stderr={stderr:?}"
+    );
+}


### PR DESCRIPTION
## Summary

The headline test for v0.1: \`tests/sip003_e2e.rs\` spawns
\`ssserver\` and \`sslocal\` as child processes, each attached to our
plugin binary via \`--plugin\` / \`--plugin-opts\`. Drives real traffic
with \`curl --socks5-hostname\` against an in-process HTTP echo server.
All on \`127.0.0.1\` with a self-signed rcgen cert. Local run: ~0.8s.

CI now installs shadowsocks-rust before the test step:
- Linux: pinned \`v1.21.2\` release tarball
- macOS: \`brew install shadowsocks-rust\`

## Other changes

- Every test in \`tests/*\` now wraps its body in a 10-minute
  \`tokio::time::timeout\`. A hang surfaces as a clean panic instead of
  a wedged \`cargo test\`.
- The plugin binary path is resolved via \`env!(\"CARGO_BIN_EXE_…\")\`,
  which cargo sets for integration tests — no escargot, no
  cargo-in-cargo.
- \`ChildGuard\` reaps the spawned ssserver/sslocal on test failure.

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --all-targets -- -D warnings\`
- [x] \`cargo test --lib --tests\` — 47 passed (44 lib + 2 loops_e2e + 1 sip003_e2e)

## Roadmap progress

PR#6 of 9. **v0.1 milestone is complete with this merge** — tunnel
works end-to-end with real shadowsocks. Next up is v0.2 (ACME
TLS-ALPN-01).

🤖 Generated with [Claude Code](https://claude.com/claude-code)