### PR TITLE
v0.3: ECH (HPKE keygen, BoringSSL FFI, e2e through real ssserver/sslocal)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -156,6 +206,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,6 +253,12 @@ checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "core-foundation"
@@ -230,8 +326,12 @@ version = "0.1.0-dev"
 dependencies = [
  "anyhow",
  "arc-swap",
+ "base64",
  "boring",
+ "boring-sys",
  "bytes",
+ "clap",
+ "foreign-types-shared",
  "futures-util",
  "http",
  "http-body-util",
@@ -240,6 +340,7 @@ dependencies = [
  "instant-acme",
  "libc",
  "pin-project-lite",
+ "rand",
  "rcgen",
  "sha2",
  "socket2 0.5.10",
@@ -615,6 +716,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -737,6 +844,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl-macros"
@@ -1141,6 +1254,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1410,6 +1529,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "valuable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,12 @@ repository = "https://github.com/shadowsocks/ech-tls-tunnel"
 [dependencies]
 anyhow = "1"
 arc-swap = "1"
+base64 = "0.22"
 boring = "4"
+boring-sys = "4"
 bytes = "1"
+clap = { version = "4", features = ["derive"] }
+foreign-types-shared = "0.3"
 futures-util = { version = "0.3", default-features = false, features = ["sink"] }
 http = "1"
 http-body-util = "0.1"
@@ -19,6 +23,7 @@ hyper-util = { version = "0.1", features = ["tokio"] }
 instant-acme = "0.7"
 libc = "0.2"
 pin-project-lite = "0.2"
+rand = "0.8"
 rcgen = "0.13"
 sha2 = "0.10"
 socket2 = { version = "0.5", features = ["all"] }

--- a/src/ech.rs
+++ b/src/ech.rs
@@ -1,0 +1,335 @@
+//! ECH (Encrypted Client Hello) — server keypair and ConfigList wiring.
+//!
+//! Server side: holds an HPKE X25519/HKDF-SHA256 keypair and the
+//! `public_name` advertised in the cleartext ClientHello. Wraps
+//! BoringSSL's `EVP_HPKE_KEY_*` and `SSL_*_ech_*` FFI from `boring-sys`,
+//! which exposes the full ECH surface (`SSL_marshal_ech_config`,
+//! `SSL_ECH_KEYS_*`, `SSL_CTX_set1_ech_keys`, `SSL_set1_ech_config_list`).
+//!
+//! Client side: a single helper that takes the binary ECHConfigList
+//! (whether decoded from base64 or read from disk) and applies it to
+//! a per-connection `SslRef` before the handshake.
+//!
+//! On-disk format for the server key (see [`EchServerKey::write_to`]):
+//!
+//! ```text
+//! [u8 config_id]
+//! [u16 BE name_len]
+//! [name_len bytes UTF-8 public_name]
+//! [32 bytes raw X25519 private key]
+//! ```
+
+use std::ffi::CString;
+use std::path::Path;
+use std::ptr::NonNull;
+
+use anyhow::{bail, Context, Result};
+use base64::engine::general_purpose::STANDARD as B64;
+use base64::Engine;
+use boring::ssl::{SslContextBuilder, SslRef};
+use foreign_types_shared::ForeignTypeRef;
+
+const X25519_PRIVATE_KEY_LEN: usize = 32;
+/// `0` lets BoringSSL pick the conventional max name length when
+/// padding the ClientHelloInner.
+const MAX_NAME_LENGTH: usize = 0;
+
+/// Server-side ECH key material (HPKE X25519/HKDF-SHA256).
+#[derive(Clone)]
+pub struct EchServerKey {
+    config_id: u8,
+    public_name: String,
+    private_key: [u8; X25519_PRIVATE_KEY_LEN],
+}
+
+impl std::fmt::Debug for EchServerKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EchServerKey")
+            .field("config_id", &self.config_id)
+            .field("public_name", &self.public_name)
+            .field("private_key", &"<32 bytes>")
+            .finish()
+    }
+}
+
+/// Owned wrapper around `EVP_HPKE_KEY` with proper Drop.
+struct HpkeKey(NonNull<boring_sys::EVP_HPKE_KEY>);
+
+impl HpkeKey {
+    fn new() -> Result<Self> {
+        unsafe {
+            let p = boring_sys::EVP_HPKE_KEY_new();
+            NonNull::new(p)
+                .map(Self)
+                .ok_or_else(|| anyhow::anyhow!("EVP_HPKE_KEY_new"))
+        }
+    }
+
+    fn from_private(raw: &[u8]) -> Result<Self> {
+        let key = Self::new()?;
+        unsafe {
+            let kem = boring_sys::EVP_hpke_x25519_hkdf_sha256();
+            let rc = boring_sys::EVP_HPKE_KEY_init(key.0.as_ptr(), kem, raw.as_ptr(), raw.len());
+            if rc != 1 {
+                bail!("EVP_HPKE_KEY_init failed");
+            }
+        }
+        Ok(key)
+    }
+
+    fn generate() -> Result<Self> {
+        let key = Self::new()?;
+        unsafe {
+            let kem = boring_sys::EVP_hpke_x25519_hkdf_sha256();
+            let rc = boring_sys::EVP_HPKE_KEY_generate(key.0.as_ptr(), kem);
+            if rc != 1 {
+                bail!("EVP_HPKE_KEY_generate failed");
+            }
+        }
+        Ok(key)
+    }
+
+    fn private_bytes(&self) -> Result<[u8; X25519_PRIVATE_KEY_LEN]> {
+        let mut out = [0u8; X25519_PRIVATE_KEY_LEN];
+        let mut out_len: usize = 0;
+        let rc = unsafe {
+            boring_sys::EVP_HPKE_KEY_private_key(
+                self.0.as_ptr(),
+                out.as_mut_ptr(),
+                &mut out_len,
+                out.len(),
+            )
+        };
+        if rc != 1 {
+            bail!("EVP_HPKE_KEY_private_key failed");
+        }
+        if out_len != X25519_PRIVATE_KEY_LEN {
+            bail!("unexpected HPKE private key length: {out_len}");
+        }
+        Ok(out)
+    }
+}
+
+impl Drop for HpkeKey {
+    fn drop(&mut self) {
+        unsafe { boring_sys::EVP_HPKE_KEY_free(self.0.as_ptr()) }
+    }
+}
+
+impl EchServerKey {
+    /// Generate a fresh keypair with a random `config_id`.
+    pub fn generate(public_name: &str) -> Result<Self> {
+        if public_name.is_empty() {
+            bail!("ECH public_name must be non-empty");
+        }
+        let key = HpkeKey::generate()?;
+        Ok(Self {
+            config_id: rand::random(),
+            public_name: public_name.to_string(),
+            private_key: key.private_bytes()?,
+        })
+    }
+
+    pub fn config_id(&self) -> u8 {
+        self.config_id
+    }
+    pub fn public_name(&self) -> &str {
+        &self.public_name
+    }
+
+    /// Marshal a single ECHConfig (no list wrapper) via
+    /// `SSL_marshal_ech_config`.
+    pub fn marshal_config(&self) -> Result<Vec<u8>> {
+        let key = HpkeKey::from_private(&self.private_key)?;
+        let pn = CString::new(self.public_name.as_bytes()).context("public_name has NUL byte")?;
+        let mut out: *mut u8 = std::ptr::null_mut();
+        let mut out_len: usize = 0;
+        let rc = unsafe {
+            boring_sys::SSL_marshal_ech_config(
+                &mut out,
+                &mut out_len,
+                self.config_id,
+                key.0.as_ptr(),
+                pn.as_ptr(),
+                MAX_NAME_LENGTH,
+            )
+        };
+        if rc != 1 || out.is_null() {
+            if !out.is_null() {
+                unsafe { boring_sys::OPENSSL_free(out as *mut _) };
+            }
+            bail!("SSL_marshal_ech_config failed");
+        }
+        let bytes = unsafe { std::slice::from_raw_parts(out, out_len) }.to_vec();
+        unsafe { boring_sys::OPENSSL_free(out as *mut _) };
+        Ok(bytes)
+    }
+
+    /// Wrap the single ECHConfig in a TLS-encoded ECHConfigList
+    /// (`u16` length prefix + concatenated ECHConfigs).
+    pub fn marshal_config_list(&self) -> Result<Vec<u8>> {
+        let cfg = self.marshal_config()?;
+        let len = u16::try_from(cfg.len()).context("ECHConfig too large for u16 length prefix")?;
+        let mut out = Vec::with_capacity(2 + cfg.len());
+        out.extend_from_slice(&len.to_be_bytes());
+        out.extend_from_slice(&cfg);
+        Ok(out)
+    }
+
+    /// Persist to disk in the format documented at the module level.
+    pub fn write_to(&self, path: &Path) -> Result<()> {
+        let pn = self.public_name.as_bytes();
+        let nlen = u16::try_from(pn.len()).context("public_name too long")?;
+        let mut buf = Vec::with_capacity(1 + 2 + pn.len() + X25519_PRIVATE_KEY_LEN);
+        buf.push(self.config_id);
+        buf.extend_from_slice(&nlen.to_be_bytes());
+        buf.extend_from_slice(pn);
+        buf.extend_from_slice(&self.private_key);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).ok();
+        }
+        std::fs::write(path, buf).with_context(|| format!("write {}", path.display()))
+    }
+
+    pub fn read_from(path: &Path) -> Result<Self> {
+        let buf = std::fs::read(path).with_context(|| format!("read {}", path.display()))?;
+        if buf.len() < 3 {
+            bail!("ECH key file too short (got {} bytes)", buf.len());
+        }
+        let config_id = buf[0];
+        let nlen = u16::from_be_bytes([buf[1], buf[2]]) as usize;
+        let expected = 1 + 2 + nlen + X25519_PRIVATE_KEY_LEN;
+        if buf.len() != expected {
+            bail!(
+                "ECH key file length mismatch: got {} bytes, expected {} (nlen={})",
+                buf.len(),
+                expected,
+                nlen
+            );
+        }
+        let public_name = std::str::from_utf8(&buf[3..3 + nlen])
+            .context("public_name not valid UTF-8")?
+            .to_string();
+        let mut private_key = [0u8; X25519_PRIVATE_KEY_LEN];
+        private_key.copy_from_slice(&buf[3 + nlen..]);
+        Ok(Self {
+            config_id,
+            public_name,
+            private_key,
+        })
+    }
+
+    /// Install on an `SslContextBuilder` via
+    /// `SSL_ECH_KEYS_new` + `SSL_ECH_KEYS_add` + `SSL_CTX_set1_ech_keys`.
+    /// `is_retry_config = 1` so the public ECHConfig is included in the
+    /// retry config list returned to clients with stale ConfigLists.
+    pub fn install_on_ctx_builder(&self, b: &SslContextBuilder) -> Result<()> {
+        let cfg_bytes = self.marshal_config()?;
+        let key = HpkeKey::from_private(&self.private_key)?;
+        unsafe {
+            let keys = boring_sys::SSL_ECH_KEYS_new();
+            if keys.is_null() {
+                bail!("SSL_ECH_KEYS_new failed");
+            }
+            let rc = boring_sys::SSL_ECH_KEYS_add(
+                keys,
+                1,
+                cfg_bytes.as_ptr(),
+                cfg_bytes.len(),
+                key.0.as_ptr(),
+            );
+            if rc != 1 {
+                boring_sys::SSL_ECH_KEYS_free(keys);
+                bail!("SSL_ECH_KEYS_add failed");
+            }
+            let rc = boring_sys::SSL_CTX_set1_ech_keys(b.as_ptr(), keys);
+            // CTX took its own up_ref via set1_; release ours.
+            boring_sys::SSL_ECH_KEYS_free(keys);
+            if rc != 1 {
+                bail!("SSL_CTX_set1_ech_keys failed");
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Apply a binary ECHConfigList to a per-connection `SslRef` before the
+/// handshake. The bytes are exactly what
+/// [`EchServerKey::marshal_config_list`] produces on the server.
+pub fn install_client_ech_config_list(ssl: &mut SslRef, list: &[u8]) -> Result<()> {
+    let rc =
+        unsafe { boring_sys::SSL_set1_ech_config_list(ssl.as_ptr(), list.as_ptr(), list.len()) };
+    if rc != 1 {
+        bail!("SSL_set1_ech_config_list failed");
+    }
+    Ok(())
+}
+
+/// Decode a base64 ECHConfigList string.
+pub fn decode_config_list_b64(b64: &str) -> Result<Vec<u8>> {
+    B64.decode(b64.trim())
+        .context("decode ECHConfigList base64")
+}
+
+/// Encode bytes as base64 (canonical/standard alphabet, with padding).
+pub fn encode_config_list_b64(bytes: &[u8]) -> String {
+    B64.encode(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generate_then_marshal_then_load_round_trip() {
+        let key = EchServerKey::generate("front.example.com").unwrap();
+        let cfg = key.marshal_config().unwrap();
+        assert!(!cfg.is_empty());
+
+        let list = key.marshal_config_list().unwrap();
+        assert_eq!(list.len(), 2 + cfg.len());
+        assert_eq!(
+            u16::from_be_bytes([list[0], list[1]]) as usize,
+            cfg.len(),
+            "u16 length prefix should equal ECHConfig length"
+        );
+    }
+
+    #[test]
+    fn write_then_read_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ech.key");
+        let key = EchServerKey::generate("front.example.com").unwrap();
+        key.write_to(&path).unwrap();
+        let loaded = EchServerKey::read_from(&path).unwrap();
+        assert_eq!(loaded.config_id(), key.config_id());
+        assert_eq!(loaded.public_name(), key.public_name());
+        // Re-marshaling from the loaded key produces the same bytes as
+        // marshaling from the original (deterministic given inputs).
+        let a = key.marshal_config().unwrap();
+        let b = loaded.marshal_config().unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn empty_public_name_rejected() {
+        assert!(EchServerKey::generate("").is_err());
+    }
+
+    #[test]
+    fn read_short_file_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("bad.key");
+        std::fs::write(&path, b"x").unwrap();
+        assert!(EchServerKey::read_from(&path).is_err());
+    }
+
+    #[test]
+    fn b64_round_trip() {
+        let key = EchServerKey::generate("front.example.com").unwrap();
+        let list = key.marshal_config_list().unwrap();
+        let b64 = encode_config_list_b64(&list);
+        let decoded = decode_config_list_b64(&b64).unwrap();
+        assert_eq!(decoded, list);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod acme;
 pub mod challenge;
 pub mod client;
 pub mod config;
+pub mod ech;
 pub mod net;
 pub mod server;
 pub mod sip003;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,48 @@
+use std::path::PathBuf;
+
 use anyhow::Result;
+use clap::{Parser, Subcommand};
 use ech_tls_tunnel::config::Config;
+use ech_tls_tunnel::ech::{encode_config_list_b64, EchServerKey};
 use ech_tls_tunnel::sip003::SipEnv;
 use ech_tls_tunnel::{client, server};
 use tracing::error;
 
-fn main() -> Result<()> {
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()),
-        )
-        .init();
+#[derive(Parser)]
+#[command(
+    name = "ech-tls-tunnel",
+    about = "SIP003 plugin: shadowsocks over WebSocket / TLS / ECH"
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: Option<Cmd>,
+}
 
+#[derive(Subcommand)]
+enum Cmd {
+    /// Generate an HPKE X25519 keypair, write the private key to
+    /// `<out>/ech.key`, write the binary ECHConfigList to
+    /// `<out>/ech.config_list`, and print the base64 ECHConfigList
+    /// (ready to paste into the client's `ech_config=` plugin option).
+    EchGenKeys {
+        /// Outer (cleartext) SNI to advertise to public observers.
+        #[arg(long)]
+        public_name: String,
+        /// Output directory.
+        #[arg(long, default_value = "/var/lib/ech-tls-tunnel/ech")]
+        out: PathBuf,
+    },
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+
+    if let Some(cmd) = cli.command {
+        return run_subcommand(cmd);
+    }
+
+    // No subcommand → SIP003 plugin mode.
+    init_tracing();
     let sip = SipEnv::from_env()?;
     let mode = sip.options.mode()?;
     let cfg = Config::from_options(&sip.options)?;
@@ -30,4 +62,41 @@ fn main() -> Result<()> {
         }
         result
     })
+}
+
+fn run_subcommand(cmd: Cmd) -> Result<()> {
+    match cmd {
+        Cmd::EchGenKeys { public_name, out } => {
+            std::fs::create_dir_all(&out)?;
+            let key = EchServerKey::generate(&public_name)?;
+            let key_path = out.join("ech.key");
+            key.write_to(&key_path)?;
+            let list = key.marshal_config_list()?;
+            let list_path = out.join("ech.config_list");
+            std::fs::write(&list_path, &list)?;
+            let b64 = encode_config_list_b64(&list);
+            println!("Wrote {}", key_path.display());
+            println!("Wrote {}", list_path.display());
+            println!();
+            println!("ECHConfigList (base64):");
+            println!("{b64}");
+            println!();
+            println!("Server plugin options:");
+            println!(
+                "    ech_public_name={public_name};ech_key={}",
+                key_path.display()
+            );
+            println!("Client plugin options:");
+            println!("    ech_config={b64}");
+            Ok(())
+        }
+    }
+}
+
+fn init_tracing() {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()),
+        )
+        .init();
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -167,7 +167,8 @@ async fn build_tls_server(cfg: &ServerCfg, challenges: Arc<ChallengeStore>) -> R
                     .await?
                 }
             };
-            let server = TlsServer::build_from_pem_with(&cert.cert_pem, &cert.key_pem, challenges)?;
+            let server =
+                TlsServer::build_from_pem_with(cfg, &cert.cert_pem, &cert.key_pem, challenges)?;
             Ok(server)
         }
     }

--- a/src/sip003.rs
+++ b/src/sip003.rs
@@ -111,6 +111,10 @@ impl PluginOptions {
     /// - each option is `key=value` or just `key` (value defaults to `""`)
     /// - backslash escapes `\;`, `\=`, and `\\` allow those literals
     ///   inside keys or values
+    /// - within a single option, only the *first* unescaped `=` is the
+    ///   key/value separator; any subsequent `=` characters are part of
+    ///   the value verbatim. This matters for values that legitimately
+    ///   contain `=` (e.g. base64 padding in `ech_config=AAAA==`).
     pub fn parse(s: &str) -> Result<Self> {
         let mut map = HashMap::new();
 
@@ -118,18 +122,12 @@ impl PluginOptions {
             if raw.is_empty() {
                 continue;
             }
-            let pieces = split_unescaped(&raw, '=');
-            let mut it = pieces.into_iter();
-            let key = unescape(it.next().unwrap_or_default());
-            let value = it.next().map(unescape).unwrap_or_default();
-            if it.next().is_some() {
-                return Err(anyhow!(
-                    "plugin option {key:?} has more than one unescaped `=`"
-                ));
-            }
+            let (raw_key, raw_value) = split_first_unescaped(&raw, '=');
+            let key = unescape(raw_key);
             if key.is_empty() {
                 return Err(anyhow!("empty key in plugin options: {s:?}"));
             }
+            let value = raw_value.map(unescape).unwrap_or_default();
             map.insert(key, value);
         }
 
@@ -181,6 +179,28 @@ fn split_unescaped(s: &str, delim: char) -> Vec<String> {
     }
     out.push(current);
     out
+}
+
+/// Split `s` at the FIRST unescaped occurrence of `delim`. Returns
+/// `(before, Some(after))` if a delimiter was found, otherwise
+/// `(s_clone, None)`.
+fn split_first_unescaped(s: &str, delim: char) -> (String, Option<String>) {
+    let mut before = String::new();
+    let mut chars = s.chars();
+    while let Some(c) = chars.next() {
+        if c == '\\' {
+            before.push(c);
+            if let Some(next) = chars.next() {
+                before.push(next);
+            }
+        } else if c == delim {
+            let after: String = chars.collect();
+            return (before, Some(after));
+        } else {
+            before.push(c);
+        }
+    }
+    (before, None)
 }
 
 /// Resolve `\;`, `\=`, `\\` (and `\<other>` → `<other>`) in `s`.
@@ -307,9 +327,18 @@ mod tests {
     }
 
     #[test]
-    fn plugin_options_extra_unescaped_equals_errors() {
-        let err = PluginOptions::parse("k=a=b").unwrap_err();
-        assert!(format!("{err:#}").contains("more than one unescaped"));
+    fn plugin_options_only_first_equals_splits() {
+        // Subsequent `=` chars are part of the value verbatim. This is
+        // what lets us pass a base64 ECHConfigList (which often ends in
+        // `==`) without escaping.
+        let opts = PluginOptions::parse("k=a=b").unwrap();
+        assert_eq!(opts.get("k"), Some("a=b"));
+    }
+
+    #[test]
+    fn plugin_options_base64_value_with_padding() {
+        let opts = PluginOptions::parse("ech_config=AEf+DQA9AA==").unwrap();
+        assert_eq!(opts.get("ech_config"), Some("AEf+DQA9AA=="));
     }
 
     #[test]

--- a/src/tls_client.rs
+++ b/src/tls_client.rs
@@ -12,11 +12,14 @@ use boring::x509::X509;
 use tokio::net::TcpStream;
 use tokio_boring::SslStream;
 
-use crate::config::{ClientCfg, ClientTrust};
+use crate::config::{ClientCfg, ClientEch, ClientTrust};
+use crate::ech;
 use crate::tls_server::alpn_wire;
 
 pub struct TlsClient {
     connector: Arc<SslConnector>,
+    /// Binary ECHConfigList to apply per-connection. `None` disables ECH.
+    ech_config_list: Option<Vec<u8>>,
 }
 
 impl std::fmt::Debug for TlsClient {
@@ -52,19 +55,46 @@ impl TlsClient {
         }
         b.set_alpn_protos(&alpn_wire(&[b"h2", b"http/1.1"]))
             .context("set ALPN")?;
+
+        let ech_config_list = match &cfg.ech {
+            None => None,
+            Some(ClientEch::Inline(b64)) => Some(ech::decode_config_list_b64(b64)?),
+            Some(ClientEch::File(path)) => Some(
+                std::fs::read(path)
+                    .with_context(|| format!("read ECH config list {}", path.display()))?,
+            ),
+        };
+
         Ok(Self {
             connector: Arc::new(b.build()),
+            ech_config_list,
         })
     }
 
     /// Open a TLS connection over an already-connected TCP stream.
-    /// `sni` is the server name presented in the ClientHello (and used
-    /// for hostname verification when trust isn't `InsecureSkipVerify`).
+    /// `sni` is the server name presented in the (inner) ClientHello and
+    /// used for hostname verification when trust isn't
+    /// `InsecureSkipVerify`. When ECH is enabled the outer SNI is
+    /// derived from the configured `public_name` inside the
+    /// ECHConfigList.
     pub async fn connect(&self, sni: &str, tcp: TcpStream) -> Result<SslStream<TcpStream>> {
         let cfg = self.connector.configure().context("configure handshake")?;
-        tokio_boring::connect(cfg, sni, tcp)
-            .await
-            .map_err(|e| anyhow!("tls handshake: {e}"))
+        match &self.ech_config_list {
+            None => tokio_boring::connect(cfg, sni, tcp)
+                .await
+                .map_err(|e| anyhow!("tls handshake: {e}")),
+            Some(list) => {
+                let mut ssl = cfg
+                    .into_ssl(sni)
+                    .context("ConnectConfiguration::into_ssl")?;
+                ech::install_client_ech_config_list(&mut ssl, list)
+                    .context("install client ECH config list")?;
+                tokio_boring::SslStreamBuilder::new(ssl, tcp)
+                    .connect()
+                    .await
+                    .map_err(|e| anyhow!("tls handshake (ECH): {e}"))
+            }
+        }
     }
 }
 

--- a/src/tls_server.rs
+++ b/src/tls_server.rs
@@ -16,7 +16,8 @@ use tokio::net::TcpStream;
 use tokio_boring::SslStream;
 
 use crate::challenge::ChallengeStore;
-use crate::config::{ServerCfg, ServerTls};
+use crate::config::{ServerCfg, ServerEch, ServerTls};
+use crate::ech::EchServerKey;
 
 /// Live TLS acceptor backed by BoringSSL. The inner [`SslAcceptor`] sits
 /// behind `ArcSwap` so the ACME task can hot-swap it on cert renewal.
@@ -51,7 +52,7 @@ impl TlsServer {
                 ))
             }
         };
-        let acceptor = build_acceptor_from_pem(cert_file, key_file, challenges)?;
+        let acceptor = build_acceptor_from_pem(cert_file, key_file, challenges, cfg.ech.as_ref())?;
         Ok(Self {
             acceptor: Arc::new(ArcSwap::from_pointee(acceptor)),
         })
@@ -59,13 +60,15 @@ impl TlsServer {
 
     /// Build from cert/key already in memory (PEM strings) plus a
     /// `ChallengeStore`. Used by the ACME path which has just received
-    /// a freshly-issued cert.
+    /// a freshly-issued cert. Reads ECH config from `cfg.ech` if any.
     pub fn build_from_pem_with(
+        cfg: &ServerCfg,
         cert_pem: &str,
         key_pem: &str,
         challenges: Arc<ChallengeStore>,
     ) -> Result<Self> {
-        let acceptor = build_acceptor_from_pem_strs(cert_pem, key_pem, challenges)?;
+        let acceptor =
+            build_acceptor_from_pem_strs(cert_pem, key_pem, challenges, cfg.ech.as_ref())?;
         Ok(Self {
             acceptor: Arc::new(ArcSwap::from_pointee(acceptor)),
         })
@@ -89,6 +92,7 @@ fn build_acceptor_from_pem(
     cert: &Path,
     key: &Path,
     challenges: Arc<ChallengeStore>,
+    ech: Option<&ServerEch>,
 ) -> Result<SslAcceptor> {
     let mut b = SslAcceptor::mozilla_intermediate_v5(SslMethod::tls())
         .context("init SslAcceptorBuilder")?;
@@ -98,6 +102,7 @@ fn build_acceptor_from_pem(
         .with_context(|| format!("load key {}", key.display()))?;
     b.check_private_key().context("cert/key pair check")?;
     install_alpn_callback(&mut b, challenges)?;
+    install_ech_if_configured(&b, ech)?;
     Ok(b.build())
 }
 
@@ -105,6 +110,7 @@ fn build_acceptor_from_pem_strs(
     cert_pem: &str,
     key_pem: &str,
     challenges: Arc<ChallengeStore>,
+    ech: Option<&ServerEch>,
 ) -> Result<SslAcceptor> {
     use boring::pkey::PKey;
     use boring::x509::X509;
@@ -122,7 +128,30 @@ fn build_acceptor_from_pem_strs(
     b.set_private_key(&pkey).context("set private key")?;
     b.check_private_key().context("cert/key pair check")?;
     install_alpn_callback(&mut b, challenges)?;
+    install_ech_if_configured(&b, ech)?;
     Ok(b.build())
+}
+
+/// Read the HPKE keypair from `ech.key_file` and install it on the
+/// builder via `SSL_CTX_set1_ech_keys`. No-op when ECH isn't
+/// configured.
+fn install_ech_if_configured(
+    b: &boring::ssl::SslContextBuilder,
+    ech: Option<&ServerEch>,
+) -> Result<()> {
+    let Some(cfg) = ech else { return Ok(()) };
+    let key = EchServerKey::read_from(&cfg.key_file)
+        .with_context(|| format!("read ECH key {}", cfg.key_file.display()))?;
+    if key.public_name() != cfg.public_name {
+        tracing::warn!(
+            "ECH public_name mismatch: stored={:?}, config={:?}",
+            key.public_name(),
+            cfg.public_name
+        );
+    }
+    key.install_on_ctx_builder(b)?;
+    tracing::info!("ECH enabled (public_name={})", key.public_name());
+    Ok(())
 }
 
 /// Install the ALPN-select callback that:
@@ -322,6 +351,7 @@ mod tests {
             &cert_path,
             &key_path,
             Arc::new(crate::challenge::ChallengeStore::new()),
+            None,
         )
         .unwrap();
         server.swap(new_acceptor);

--- a/tests/sip003_e2e.rs
+++ b/tests/sip003_e2e.rs
@@ -222,3 +222,124 @@ async fn sip003_full_pipeline_with_shadowsocks_rust_inner() {
         "unexpected response body: stdout={stdout:?} stderr={stderr:?}"
     );
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn sip003_full_pipeline_with_ech() {
+    tokio::time::timeout(TEST_TIMEOUT, sip003_full_pipeline_with_ech_inner())
+        .await
+        .expect("sip003_e2e ECH timed out after 10 minutes");
+}
+
+async fn sip003_full_pipeline_with_ech_inner() {
+    if let Some(reason) = precondition() {
+        eprintln!("SKIP sip003_e2e ECH: {reason}");
+        return;
+    }
+
+    use ech_tls_tunnel::ech::{encode_config_list_b64, EchServerKey};
+    let plugin_path: PathBuf = env!("CARGO_BIN_EXE_ech-tls-tunnel").into();
+
+    // Self-signed cert covering both the inner and outer SNI: the
+    // server presents a cert valid for `public_name` to plain probes
+    // and a cert valid for `tunnel.local` only after ECH decryption.
+    // For this test we use a single SAN list — handshake succeeds
+    // either way because the test client trusts our cert directly.
+    let kp = rcgen::generate_simple_self_signed(vec!["tunnel.local".into(), "front.local".into()])
+        .unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    let cert_path = dir.path().join("cert.pem");
+    let key_path = dir.path().join("key.pem");
+    std::fs::write(&cert_path, kp.cert.pem()).unwrap();
+    std::fs::write(&key_path, kp.key_pair.serialize_pem()).unwrap();
+
+    // ECH HPKE keypair
+    let ech_key = EchServerKey::generate("front.local").unwrap();
+    let ech_key_path = dir.path().join("ech.key");
+    ech_key.write_to(&ech_key_path).unwrap();
+    let ech_b64 = encode_config_list_b64(&ech_key.marshal_config_list().unwrap());
+
+    let echo_addr = spawn_echo_server().await;
+    let tunnel_port = pick_port();
+    let local_port = pick_port();
+
+    let ssserver_opts = format!(
+        "mode=server;domain=tunnel.local;path=/ws-ech;cert={};key={};ech_public_name=front.local;ech_key={}",
+        cert_path.display(),
+        key_path.display(),
+        ech_key_path.display()
+    );
+    let _ssserver = ChildGuard(Some(
+        Command::new("ssserver")
+            .args([
+                "-s",
+                &format!("127.0.0.1:{tunnel_port}"),
+                "-k",
+                "ech-testpass",
+                "-m",
+                "aes-128-gcm",
+                "--plugin",
+                plugin_path.to_str().unwrap(),
+                "--plugin-opts",
+                &ssserver_opts,
+            ])
+            .spawn()
+            .expect("spawn ssserver"),
+    ));
+    wait_for_ready(&format!("127.0.0.1:{tunnel_port}")).await;
+
+    let sslocal_opts = format!(
+        "mode=client;sni=tunnel.local;path=/ws-ech;ca_file={};ech_config={ech_b64}",
+        cert_path.display()
+    );
+    let _sslocal = ChildGuard(Some(
+        Command::new("sslocal")
+            .args([
+                "-b",
+                &format!("127.0.0.1:{local_port}"),
+                "-s",
+                &format!("127.0.0.1:{tunnel_port}"),
+                "-k",
+                "ech-testpass",
+                "-m",
+                "aes-128-gcm",
+                "--protocol",
+                "socks",
+                "--plugin",
+                plugin_path.to_str().unwrap(),
+                "--plugin-opts",
+                &sslocal_opts,
+            ])
+            .spawn()
+            .expect("spawn sslocal"),
+    ));
+    wait_for_ready(&format!("127.0.0.1:{local_port}")).await;
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let url = format!("http://{}/ech-hello", echo_addr);
+    let out = Command::new("curl")
+        .args([
+            "--silent",
+            "--show-error",
+            "--max-time",
+            "15",
+            "--socks5-hostname",
+            &format!("127.0.0.1:{local_port}"),
+            &url,
+        ])
+        .output()
+        .expect("run curl");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "curl failed: status={:?}\nstdout: {}\nstderr: {}",
+        out.status,
+        stdout,
+        stderr
+    );
+    assert_eq!(
+        stdout.trim(),
+        "echo:/ech-hello",
+        "unexpected ECH response body: stdout={stdout:?} stderr={stderr:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Encrypted ClientHello, end-to-end. Generates an HPKE keypair, marshals
an ECHConfig via BoringSSL, installs it on the server's SSL_CTX, and
applies the ECHConfigList per-connection on the client. The
shadowsocks-rust e2e test now runs in two flavors — one without ECH,
one with — both exercising real \`ssserver\` + \`sslocal\` subprocesses.

## Files

- \`src/ech.rs\` — \`EchServerKey\` (HPKE X25519/HKDF-SHA256), keygen,
  on-disk format, marshal_config / marshal_config_list,
  install_on_ctx_builder. \`install_client_ech_config_list\` for the
  per-connection client side. base64 encode/decode helpers.
- \`src/tls_server.rs\` — \`install_ech_if_configured\` hook in both
  cert-loading paths, called before \`.build()\`.
- \`src/tls_client.rs\` — TlsClient caches the decoded ECHConfigList;
  \`connect()\` takes the \`into_ssl + SSL_set1_ech_config_list +
  SslStreamBuilder\` path when ECH is enabled.
- \`src/main.rs\` — \`ech-tls-tunnel ech-gen-keys --public-name X --out
  DIR\` subcommand (clap). No-subcommand path is SIP003 plugin mode.
- \`src/sip003.rs\` — plugin-options parser now splits on the FIRST
  unescaped \`=\`; subsequent \`=\` are part of the value. Necessary so
  a base64 ECHConfigList with padding (\`==\`) round-trips through
  \`SS_PLUGIN_OPTIONS\` without escaping.
- \`tests/sip003_e2e.rs\` — \`sip003_full_pipeline_with_ech\` test:
  spawns ssserver with \`ech_public_name=front.local;ech_key=…\` and
  sslocal with \`ech_config=<base64>\`, drives via curl, asserts
  echoed body. Server logs confirm \`ECH enabled (public_name=…)\`.

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --all-targets -- -D warnings\`
- [x] \`cargo test --lib --tests\` — 58 passed (54 lib + 2 loops_e2e + 2 sip003_e2e)
- [x] ECH path actually wired through real shadowsocks-rust ssserver/sslocal
- [ ] Wireshark-confirmed outer SNI = \`public_name\` on a real VPS — follow-up

## Roadmap progress

PR#8 of 9. v0.3 milestone done — every TLS handshake the tunnel sees
in the ECH path is decrypted via the configured HPKE keypair. Next is
v0.4 polish (release artifacts, structured logs, README).

🤖 Generated with [Claude Code](https://claude.com/claude-code)