### PR TITLE
client: emulate browser TLS fingerprints (chrome/firefox/safari/ios/android/edge/random)

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ on the wire) like an HTTPS connection to `front.example.com`.
 | `ech_config_file` | — | Path to a binary ECHConfigList file (alternative to `ech_config`). |
 | `ca_file` | — | Pin to a specific CA bundle (PEM). Mutually exclusive with `insecure`. |
 | `insecure` | `false` | DEV/TEST ONLY — skip cert verification. |
+| `fingerprint` | — | Browser-fingerprint shaping for the TLS ClientHello. One of `chrome`, `firefox`, `safari`, `ios`, `android`, `edge`, or `random`. Versioned aliases (`chrome120`, `safari16`, …) also accepted. See [src/fingerprint.rs](src/fingerprint.rs) for the profile bodies. |
 
 ## CLI subcommands
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -60,6 +60,19 @@ Each item maps to a small, mergeable PR.
       shadowsocks-rust ssserver/sslocal (`sip003_full_pipeline_with_ech`)
 - [ ] VPS smoke + Wireshark capture review (manual, follow-up)
 
+## Post-v0.4 — Client browser fingerprint ✅
+
+- [x] `src/fingerprint.rs` — `FingerprintParams` + 6 profile constants
+      (Chrome, Firefox, Safari, iOS, Android, Edge) + `random` weighted
+- [x] `fingerprint=` plugin option on the client side
+- [x] Applied via boring's `set_cipher_list` / `set_curves_list` /
+      `set_grease_enabled` / `set_permute_extensions` /
+      `set_sigalgs_list`
+- [x] Profiles ported from `metacubex/utls` `u_parrots.go` (via
+      mihomo-rust's port)
+- [x] e2e test runs the non-ECH path with `fingerprint=chrome`
+      through real `sslocal`
+
 ## v0.4 — Polish ✅
 
 - [x] README rewrite with deployment recipe

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,6 +26,8 @@
 //! - `ech_config=<base64>` — or — `ech_config_file=<path>` (enables ECH)
 //! - `ca_file=<path>` (override default trust store)
 //! - `insecure=true` (DEV/TEST ONLY — disable verification)
+//! - `fingerprint=<profile>` (TLS ClientHello shaping; one of
+//!   `chrome|firefox|safari|ios|android|edge|random`)
 
 use std::path::PathBuf;
 
@@ -77,6 +79,10 @@ pub struct ClientCfg {
     pub ech: Option<ClientEch>,
     /// Trust source for verifying the upstream cert.
     pub trust: ClientTrust,
+    /// Browser-fingerprint profile for the TLS ClientHello.
+    /// `None` = boring defaults; otherwise one of the names accepted by
+    /// [`crate::fingerprint::resolve`].
+    pub fingerprint: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -150,6 +156,7 @@ impl ClientCfg {
         let fast_open = parse_bool(o, "fast_open")?.unwrap_or(false);
         let ech = build_client_ech(o)?;
         let trust = build_client_trust(o)?;
+        let fingerprint = build_fingerprint(o)?;
 
         Ok(Self {
             sni,
@@ -157,8 +164,27 @@ impl ClientCfg {
             fast_open,
             ech,
             trust,
+            fingerprint,
         })
     }
+}
+
+fn build_fingerprint(o: &PluginOptions) -> Result<Option<String>> {
+    let Some(raw) = o.get("fingerprint") else {
+        return Ok(None);
+    };
+    let normalized = raw.trim().to_ascii_lowercase();
+    if normalized.is_empty() {
+        return Ok(None);
+    }
+    if crate::fingerprint::resolve(&normalized).is_none() {
+        return Err(anyhow!(
+            "unknown fingerprint {raw:?}; expected one of \
+             chrome|firefox|safari|ios|android|edge|random \
+             (or a versioned alias like chrome120, firefox120, safari16, ios14, android11, edge85)"
+        ));
+    }
+    Ok(Some(normalized))
 }
 
 fn required(o: &PluginOptions, key: &str) -> Result<String> {
@@ -453,5 +479,38 @@ mod tests {
     fn parse_bool_rejects_garbage() {
         let err = err_str("mode=server;domain=t.x;path=/ws;cert=/c;key=/k;fast_open=maybe");
         assert!(err.contains("boolean"));
+    }
+
+    #[test]
+    fn client_fingerprint_recognized_names() {
+        for fp in [
+            "chrome",
+            "Chrome",
+            "firefox",
+            "safari",
+            "ios",
+            "android",
+            "edge",
+            "random",
+            "chrome120",
+        ] {
+            let c = client_cfg(&format!("mode=client;sni=t.x;path=/ws;fingerprint={fp}"));
+            assert_eq!(c.fingerprint, Some(fp.to_ascii_lowercase()));
+        }
+    }
+
+    #[test]
+    fn client_fingerprint_default_is_none() {
+        let c = client_cfg("mode=client;sni=t.x;path=/ws");
+        assert!(c.fingerprint.is_none());
+    }
+
+    #[test]
+    fn client_fingerprint_unknown_errors() {
+        let err = err_str("mode=client;sni=t.x;path=/ws;fingerprint=netscape");
+        assert!(
+            err.contains("unknown fingerprint"),
+            "expected unknown fingerprint error, got: {err}"
+        );
     }
 }

--- a/src/fingerprint.rs
+++ b/src/fingerprint.rs
@@ -1,0 +1,288 @@
+//! Client TLS fingerprint emulation (a.k.a. uTLS / browser-impersonation).
+//!
+//! By default `boring`'s `SslConnector` produces a recognizable
+//! BoringSSL ClientHello: cipher order, curve order, sigalg order, and
+//! the absence of GREASE all give it away. A DPI box keyed on JA3/JA4
+//! can distinguish that from real browser traffic even after we wrap it
+//! in WebSocket-over-TLS.
+//!
+//! This module ports mihomo-rust's profile-based approach: each profile
+//! is a small bundle of OpenSSL-format strings + booleans that drive
+//! the BoringSSL context-builder knobs:
+//!
+//! - `set_cipher_list` — TLS 1.2 cipher order (1.3 ciphers are
+//!   BoringSSL-fixed and prepended).
+//! - `set_curves_list` — named-group order.
+//! - `set_grease_enabled` — RFC 8701 GREASE in ciphers, extensions, and
+//!   groups; also enables ECH GREASE.
+//! - `set_permute_extensions` — extension-order randomization
+//!   (Chrome 106+).
+//! - `set_sigalgs_list` — signature algorithm order.
+//!
+//! The profile constants below are taken from
+//! `metacubex/utls`'s `u_parrots.go`.
+
+use anyhow::{Context, Result};
+use boring::ssl::SslConnectorBuilder;
+
+/// All knobs the BoringSSL builder needs to mint a ClientHello that
+/// looks like a particular browser/SDK.
+#[derive(Clone, Copy)]
+pub struct FingerprintParams {
+    pub cipher_list: &'static str,
+    pub curves_list: &'static str,
+    pub grease: bool,
+    pub permute_extensions: bool,
+    pub sigalgs_list: &'static str,
+}
+
+/// Chrome 120.
+/// Reference: utls `u_parrots.go` lines 665–736, HelloChrome_120.
+pub const CHROME: FingerprintParams = FingerprintParams {
+    cipher_list: "ECDHE-ECDSA-AES128-GCM-SHA256:\
+                  ECDHE-RSA-AES128-GCM-SHA256:\
+                  ECDHE-ECDSA-AES256-GCM-SHA384:\
+                  ECDHE-RSA-AES256-GCM-SHA384:\
+                  ECDHE-ECDSA-CHACHA20-POLY1305:\
+                  ECDHE-RSA-CHACHA20-POLY1305:\
+                  ECDHE-RSA-AES128-SHA:\
+                  ECDHE-RSA-AES256-SHA:\
+                  AES128-GCM-SHA256:\
+                  AES256-GCM-SHA384:\
+                  AES128-SHA:\
+                  AES256-SHA",
+    curves_list: "X25519:P-256:P-384",
+    grease: true,
+    permute_extensions: true,
+    sigalgs_list: "ecdsa_secp256r1_sha256:\
+                   rsa_pss_rsae_sha256:\
+                   rsa_pkcs1_sha256:\
+                   ecdsa_secp384r1_sha384:\
+                   rsa_pss_rsae_sha384:\
+                   rsa_pkcs1_sha384:\
+                   rsa_pss_rsae_sha512:\
+                   rsa_pkcs1_sha512",
+};
+
+/// Firefox 120.
+pub const FIREFOX: FingerprintParams = FingerprintParams {
+    cipher_list: "ECDHE-ECDSA-AES128-GCM-SHA256:\
+                  ECDHE-RSA-AES128-GCM-SHA256:\
+                  ECDHE-ECDSA-CHACHA20-POLY1305:\
+                  ECDHE-RSA-CHACHA20-POLY1305:\
+                  ECDHE-ECDSA-AES256-GCM-SHA384:\
+                  ECDHE-RSA-AES256-GCM-SHA384:\
+                  ECDHE-ECDSA-AES256-SHA:\
+                  ECDHE-ECDSA-AES128-SHA:\
+                  ECDHE-RSA-AES128-SHA:\
+                  ECDHE-RSA-AES256-SHA:\
+                  AES128-GCM-SHA256:\
+                  AES256-GCM-SHA384:\
+                  AES128-SHA:\
+                  AES256-SHA:\
+                  DES-CBC3-SHA",
+    curves_list: "X25519:P-256:P-384:P-521",
+    grease: false,
+    permute_extensions: false,
+    sigalgs_list: "ecdsa_secp256r1_sha256:\
+                   ecdsa_secp384r1_sha384:\
+                   ecdsa_secp521r1_sha512:\
+                   rsa_pss_rsae_sha256:\
+                   rsa_pss_rsae_sha384:\
+                   rsa_pss_rsae_sha512:\
+                   rsa_pkcs1_sha256:\
+                   rsa_pkcs1_sha384:\
+                   rsa_pkcs1_sha512",
+};
+
+/// Safari 16.
+pub const SAFARI: FingerprintParams = FingerprintParams {
+    cipher_list: "ECDHE-ECDSA-AES256-GCM-SHA384:\
+                  ECDHE-ECDSA-AES128-GCM-SHA256:\
+                  ECDHE-ECDSA-CHACHA20-POLY1305:\
+                  ECDHE-RSA-AES256-GCM-SHA384:\
+                  ECDHE-RSA-AES128-GCM-SHA256:\
+                  ECDHE-RSA-CHACHA20-POLY1305:\
+                  ECDHE-ECDSA-AES256-SHA:\
+                  ECDHE-ECDSA-AES128-SHA:\
+                  ECDHE-RSA-AES256-SHA:\
+                  ECDHE-RSA-AES128-SHA:\
+                  AES256-GCM-SHA384:\
+                  AES128-GCM-SHA256:\
+                  AES256-SHA:\
+                  AES128-SHA:\
+                  DES-CBC3-SHA",
+    curves_list: "X25519:P-256:P-384",
+    grease: false,
+    permute_extensions: false,
+    sigalgs_list: "ecdsa_secp256r1_sha256:\
+                   rsa_pss_rsae_sha256:\
+                   rsa_pkcs1_sha256:\
+                   ecdsa_secp384r1_sha384:\
+                   ecdsa_secp521r1_sha512:\
+                   rsa_pss_rsae_sha384:\
+                   rsa_pss_rsae_sha512:\
+                   rsa_pkcs1_sha384:\
+                   rsa_pkcs1_sha512:\
+                   rsa_pkcs1_sha1",
+};
+
+/// iOS 14. Cipher list matches Safari 16; sigalgs differ.
+pub const IOS: FingerprintParams = FingerprintParams {
+    cipher_list: "ECDHE-ECDSA-AES256-GCM-SHA384:\
+                  ECDHE-ECDSA-AES128-GCM-SHA256:\
+                  ECDHE-ECDSA-CHACHA20-POLY1305:\
+                  ECDHE-RSA-AES256-GCM-SHA384:\
+                  ECDHE-RSA-AES128-GCM-SHA256:\
+                  ECDHE-RSA-CHACHA20-POLY1305:\
+                  ECDHE-ECDSA-AES256-SHA:\
+                  ECDHE-ECDSA-AES128-SHA:\
+                  ECDHE-RSA-AES256-SHA:\
+                  ECDHE-RSA-AES128-SHA:\
+                  AES256-GCM-SHA384:\
+                  AES128-GCM-SHA256:\
+                  AES256-SHA:\
+                  AES128-SHA:\
+                  DES-CBC3-SHA",
+    curves_list: "X25519:P-256:P-384",
+    grease: false,
+    permute_extensions: false,
+    sigalgs_list: "ecdsa_secp256r1_sha256:\
+                   rsa_pss_rsae_sha256:\
+                   rsa_pkcs1_sha256:\
+                   ecdsa_secp384r1_sha384:\
+                   ecdsa_secp521r1_sha512:\
+                   rsa_pss_rsae_sha384:\
+                   rsa_pss_rsae_sha512:\
+                   rsa_pkcs1_sha384:\
+                   rsa_pkcs1_sha512:\
+                   rsa_pkcs1_sha1",
+};
+
+/// Android 11 (OkHttp).
+pub const ANDROID: FingerprintParams = FingerprintParams {
+    cipher_list: "ECDHE-ECDSA-AES128-GCM-SHA256:\
+                  ECDHE-RSA-AES128-GCM-SHA256:\
+                  ECDHE-ECDSA-AES256-GCM-SHA384:\
+                  ECDHE-RSA-AES256-GCM-SHA384:\
+                  ECDHE-ECDSA-CHACHA20-POLY1305:\
+                  ECDHE-RSA-CHACHA20-POLY1305:\
+                  ECDHE-RSA-AES128-SHA:\
+                  ECDHE-RSA-AES256-SHA:\
+                  AES128-GCM-SHA256:\
+                  AES256-GCM-SHA384:\
+                  AES128-SHA:\
+                  AES256-SHA",
+    curves_list: "P-256:X25519",
+    grease: false,
+    permute_extensions: false,
+    sigalgs_list: "ecdsa_secp256r1_sha256:\
+                   rsa_pss_rsae_sha256:\
+                   rsa_pkcs1_sha256:\
+                   ecdsa_secp384r1_sha384:\
+                   rsa_pss_rsae_sha384:\
+                   rsa_pkcs1_sha384:\
+                   rsa_pss_rsae_sha512:\
+                   rsa_pkcs1_sha512",
+};
+
+/// Edge 85 (Chrome 83 base — pre-permutation).
+pub const EDGE: FingerprintParams = FingerprintParams {
+    cipher_list: "ECDHE-ECDSA-AES128-GCM-SHA256:\
+                  ECDHE-RSA-AES128-GCM-SHA256:\
+                  ECDHE-ECDSA-AES256-GCM-SHA384:\
+                  ECDHE-RSA-AES256-GCM-SHA384:\
+                  ECDHE-ECDSA-CHACHA20-POLY1305:\
+                  ECDHE-RSA-CHACHA20-POLY1305:\
+                  ECDHE-RSA-AES128-SHA:\
+                  ECDHE-RSA-AES256-SHA:\
+                  AES128-GCM-SHA256:\
+                  AES256-GCM-SHA384:\
+                  AES128-SHA:\
+                  AES256-SHA",
+    curves_list: "X25519:P-256:P-384",
+    grease: true,
+    permute_extensions: false,
+    sigalgs_list: "ecdsa_secp256r1_sha256:\
+                   rsa_pss_rsae_sha256:\
+                   rsa_pkcs1_sha256:\
+                   ecdsa_secp384r1_sha384:\
+                   rsa_pss_rsae_sha384:\
+                   rsa_pkcs1_sha384:\
+                   rsa_pss_rsae_sha512:\
+                   rsa_pkcs1_sha512:\
+                   rsa_pkcs1_sha1",
+};
+
+/// Resolve a fingerprint name (lowercased ASCII) to its params. The
+/// `random` keyword picks weighted-randomly among the most common
+/// real-world distributions: chrome 6, safari 3, ios 2, firefox 1.
+pub fn resolve(fp: &str) -> Option<FingerprintParams> {
+    match fp {
+        "chrome" | "chrome120" => Some(CHROME),
+        "firefox" | "firefox120" => Some(FIREFOX),
+        "safari" | "safari16" => Some(SAFARI),
+        "ios" | "ios14" => Some(IOS),
+        "android" | "android11" => Some(ANDROID),
+        "edge" | "edge85" => Some(EDGE),
+        "random" => Some(match rand::random::<u8>() % 12 {
+            0..=5 => CHROME,
+            6..=8 => SAFARI,
+            9..=10 => IOS,
+            _ => FIREFOX,
+        }),
+        _ => None,
+    }
+}
+
+/// Apply a profile to an `SslConnectorBuilder`. Idempotent — the last
+/// caller wins.
+pub fn apply(b: &mut SslConnectorBuilder, p: &FingerprintParams) -> Result<()> {
+    b.set_cipher_list(p.cipher_list)
+        .context("set_cipher_list")?;
+    b.set_curves_list(p.curves_list)
+        .context("set_curves_list")?;
+    b.set_sigalgs_list(p.sigalgs_list)
+        .context("set_sigalgs_list")?;
+    b.set_grease_enabled(p.grease);
+    b.set_permute_extensions(p.permute_extensions);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_known_profiles() {
+        for name in [
+            "chrome",
+            "chrome120",
+            "firefox",
+            "firefox120",
+            "safari",
+            "safari16",
+            "ios",
+            "ios14",
+            "android",
+            "android11",
+            "edge",
+            "edge85",
+        ] {
+            assert!(resolve(name).is_some(), "missing profile {name}");
+        }
+    }
+
+    #[test]
+    fn random_returns_a_profile() {
+        for _ in 0..32 {
+            assert!(resolve("random").is_some());
+        }
+    }
+
+    #[test]
+    fn unknown_returns_none() {
+        assert!(resolve("netscape").is_none());
+        assert!(resolve("").is_none());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod challenge;
 pub mod client;
 pub mod config;
 pub mod ech;
+pub mod fingerprint;
 pub mod net;
 pub mod server;
 pub mod sip003;

--- a/src/tls_client.rs
+++ b/src/tls_client.rs
@@ -14,6 +14,7 @@ use tokio_boring::SslStream;
 
 use crate::config::{ClientCfg, ClientEch, ClientTrust};
 use crate::ech;
+use crate::fingerprint;
 use crate::tls_server::alpn_wire;
 
 pub struct TlsClient {
@@ -55,6 +56,18 @@ impl TlsClient {
         }
         b.set_alpn_protos(&alpn_wire(&[b"h2", b"http/1.1"]))
             .context("set ALPN")?;
+
+        // Browser-fingerprint shaping (a.k.a. uTLS / impersonation).
+        // Applied AFTER ALPN so that the GREASE / permute behaviour is
+        // determined by the chosen profile.
+        if let Some(name) = &cfg.fingerprint {
+            let params = fingerprint::resolve(name).ok_or_else(|| {
+                anyhow!("unknown fingerprint {name:?} (config validation should have caught this)")
+            })?;
+            fingerprint::apply(&mut b, &params)
+                .with_context(|| format!("apply fingerprint {name:?}"))?;
+            tracing::info!("client TLS fingerprint: {name}");
+        }
 
         let ech_config_list = match &cfg.ech {
             None => None,
@@ -168,6 +181,7 @@ mod tests {
             fast_open: false,
             ech: None::<ClientEch>,
             trust,
+            fingerprint: None,
         }
     }
 

--- a/tests/loops_e2e.rs
+++ b/tests/loops_e2e.rs
@@ -109,6 +109,7 @@ async fn full_loop_round_trips_payload() {
             fast_open: false,
             ech: None,
             trust: ClientTrust::CaFile(cert_path),
+            fingerprint: None,
         };
         let client_listen = local_addr.clone();
         let client_upstream = tunnel_addr.clone();

--- a/tests/sip003_e2e.rs
+++ b/tests/sip003_e2e.rs
@@ -162,7 +162,7 @@ async fn sip003_full_pipeline_with_shadowsocks_rust_inner() {
 
     // ── sslocal + plugin ─────────────────────────────────────────────
     let sslocal_opts = format!(
-        "mode=client;sni=tunnel.local;path=/ws-test;ca_file={}",
+        "mode=client;sni=tunnel.local;path=/ws-test;ca_file={};fingerprint=chrome",
         cert_path.display()
     );
     let _sslocal = ChildGuard(Some(


### PR DESCRIPTION
## Summary

Ported from \`mihomo-rust\` (which ports from \`metacubex/utls\`):
client-side TLS ClientHello shaping so the handshake doesn't look
like a generic BoringSSL client to a JA3/JA4-keyed DPI box, even
before WebSocket framing or ECH.

\`src/fingerprint.rs\` holds 6 profile constants — \`CHROME\` (120),
\`FIREFOX\` (120), \`SAFARI\` (16), \`IOS\` (14), \`ANDROID\` (11
OkHttp), \`EDGE\` (85) — plus a \`random\` keyword that picks
weighted-randomly: chrome 6, safari 3, ios 2, firefox 1 (rough
browser-market-share approximation).

Each profile drives boring's:
- \`set_cipher_list\` (TLS 1.2 cipher order)
- \`set_curves_list\` (named-group order)
- \`set_grease_enabled\` (RFC 8701 GREASE)
- \`set_permute_extensions\` (Chrome 106+ extension shuffle)
- \`set_sigalgs_list\` (signature algorithm order)

## Plugin option

\`\`\`
fingerprint=chrome|firefox|safari|ios|android|edge|random
\`\`\`

Versioned aliases also accepted: \`chrome120\`, \`firefox120\`,
\`safari16\`, \`ios14\`, \`android11\`, \`edge85\`. Names are
case-insensitive. Unknown names error at config load (not at first
connect).

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --all-targets -- -D warnings\`
- [x] \`cargo test --lib --tests\` — all green; the e2e
      \`sip003_full_pipeline_with_shadowsocks_rust\` now runs sslocal
      with \`fingerprint=chrome\`, log line "client TLS fingerprint:
      chrome" confirms the path engaged.

## Roadmap progress

Post-v0.4 follow-up. Closes the gap that DPI keyed on TLS
fingerprint could still distinguish even ECH-wrapped traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)