### PR TITLE
server: bind listener before ACME, wire up auto-renewal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "asn1-rs"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -92,6 +131,35 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+dependencies = [
+ "aws-lc-sys",
+ "untrusted 0.7.1",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
 
 [[package]]
 name = "base64"
@@ -176,6 +244,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -261,6 +331,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -302,6 +382,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -319,6 +413,23 @@ dependencies = [
  "block-buffer",
  "crypto-common",
 ]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "ech-tls-tunnel"
@@ -341,7 +452,7 @@ dependencies = [
  "libc",
  "pin-project-lite",
  "rand",
- "rcgen",
+ "rcgen 0.13.2",
  "sha2",
  "socket2 0.5.10",
  "tempfile",
@@ -506,13 +617,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -650,6 +773,7 @@ dependencies = [
  "hyper-util",
  "rustls",
  "rustls-native-certs",
+ "rustls-platform-verifier",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -695,24 +819,28 @@ dependencies = [
 
 [[package]]
 name = "instant-acme"
-version = "0.7.2"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37221e690dcc5d0ea7c1f70decda6ae3495e72e8af06bca15e982193ffdf4fc4"
+checksum = "9f05ad37c421b962354c358d347d4a6130151df9407978372d3ad7f0c8f71a64"
 dependencies = [
  "async-trait",
+ "aws-lc-rs",
  "base64",
  "bytes",
  "http",
  "http-body",
  "http-body-util",
+ "httpdate",
  "hyper",
  "hyper-rustls",
  "hyper-util",
- "ring",
+ "rcgen 0.14.7",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]
@@ -735,6 +863,65 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "lazy_static"
@@ -834,10 +1021,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
+]
 
 [[package]]
 name = "once_cell"
@@ -929,6 +1153,12 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
@@ -977,6 +1207,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10b99e0098aa4082912d4c649628623db6aba77335e4f4569ff5083a6448b32e"
+dependencies = [
+ "aws-lc-rs",
+ "pem",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1015,7 +1259,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -1024,6 +1268,24 @@ name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
 
 [[package]]
 name = "rustix"
@@ -1057,8 +1319,8 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -1087,14 +1349,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -1102,6 +1392,15 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -1222,6 +1521,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1277,6 +1592,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1295,7 +1621,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -1303,6 +1638,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1325,10 +1671,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -1336,6 +1684,16 @@ name = "time-core"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "tokio"
@@ -1496,7 +1854,7 @@ dependencies = [
  "log",
  "rand",
  "sha1",
- "thiserror",
+ "thiserror 1.0.69",
  "utf-8",
 ]
 
@@ -1517,6 +1875,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"
@@ -1547,6 +1911,16 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"
@@ -1616,6 +1990,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "which"
 version = "6.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1642,6 +2025,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -1835,6 +2227,24 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "aws-lc-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ http = "1"
 http-body-util = "0.1"
 hyper = { version = "1", features = ["http1", "server"] }
 hyper-util = { version = "0.1", features = ["tokio"] }
-instant-acme = "0.7"
+instant-acme = "0.8"
 libc = "0.2"
 pin-project-lite = "0.2"
 rand = "0.8"

--- a/src/acme.rs
+++ b/src/acme.rs
@@ -86,54 +86,55 @@ pub async fn issue(
         }
     });
 
-    let (account, _credentials) = Account::create(
-        &NewAccount {
-            contact: &[&format!("mailto:{email}")],
-            terms_of_service_agreed: true,
-            only_return_existing: false,
-        },
-        &directory,
-        None,
-    )
-    .await
-    .context("create ACME account")?;
+    let (account, _credentials) = Account::builder()
+        .context("init ACME account builder")?
+        .create(
+            &NewAccount {
+                contact: &[&format!("mailto:{email}")],
+                terms_of_service_agreed: true,
+                only_return_existing: false,
+            },
+            directory,
+            None,
+        )
+        .await
+        .context("create ACME account")?;
 
     let identifiers: Vec<Identifier> = domains
         .iter()
         .map(|d| Identifier::Dns((*d).to_string()))
         .collect();
     let mut order = account
-        .new_order(&NewOrder {
-            identifiers: &identifiers,
-        })
+        .new_order(&NewOrder::new(&identifiers))
         .await
         .context("new order")?;
 
-    let authorizations = order.authorizations().await.context("get authorizations")?;
-    let mut active_challenges = Vec::new();
-    for authz in &authorizations {
-        if authz.status != AuthorizationStatus::Pending {
-            continue;
+    let mut active_domains: Vec<String> = Vec::new();
+    {
+        let mut authzs = order.authorizations();
+        loop {
+            match authzs.next().await {
+                None => break,
+                Some(Err(e)) => return Err(anyhow!("get authorization: {e}")),
+                Some(Ok(mut authz)) => {
+                    if authz.status != AuthorizationStatus::Pending {
+                        continue;
+                    }
+                    let domain = match authz.identifier().identifier {
+                        Identifier::Dns(d) => d.clone(),
+                        other => return Err(anyhow!("unexpected identifier {other:?}")),
+                    };
+                    let mut challenge = authz
+                        .challenge(ChallengeType::TlsAlpn01)
+                        .ok_or_else(|| anyhow!("no tls-alpn-01 challenge for {domain}"))?;
+                    let key_auth = challenge.key_authorization();
+                    let ctx = build_challenge_ctx(&domain, &key_auth)?;
+                    challenges.install(domain.clone(), ctx);
+                    challenge.set_ready().await.context("set challenge ready")?;
+                    active_domains.push(domain);
+                }
+            }
         }
-        let challenge = authz
-            .challenges
-            .iter()
-            .find(|c| c.r#type == ChallengeType::TlsAlpn01)
-            .ok_or_else(|| anyhow!("no tls-alpn-01 challenge for {:?}", authz.identifier))?;
-        let key_auth = order.key_authorization(challenge);
-        let domain = match &authz.identifier {
-            Identifier::Dns(d) => d.clone(),
-        };
-        let ctx = build_challenge_ctx(&domain, &key_auth)?;
-        challenges.install(domain.clone(), ctx);
-        active_challenges.push((challenge.url.clone(), domain));
-    }
-
-    for (url, _) in &active_challenges {
-        order
-            .set_challenge_ready(url)
-            .await
-            .context("set challenge ready")?;
     }
 
     // Poll until ready or invalid (~2 minutes max).
@@ -143,7 +144,7 @@ pub async fn issue(
     }
 
     // Cleanup challenge entries.
-    for (_, domain) in &active_challenges {
+    for domain in &active_domains {
         challenges.remove(domain);
     }
 
@@ -159,7 +160,10 @@ pub async fn issue(
         .der()
         .to_vec();
 
-    order.finalize(&csr_der).await.context("finalize order")?;
+    order
+        .finalize_csr(&csr_der)
+        .await
+        .context("finalize order")?;
 
     // Wait for the cert to be issued (~30s max).
     let cert_chain_pem = poll_until_certificate(&mut order, 30, Duration::from_secs(2)).await?;

--- a/src/server.rs
+++ b/src/server.rs
@@ -23,7 +23,7 @@ use crate::challenge::ChallengeStore;
 use crate::config::{ServerCfg, ServerTls};
 use crate::net;
 use crate::stealth;
-use crate::tls_server::TlsServer;
+use crate::tls_server::{build_acceptor_from_pem_strs_pub, TlsServer};
 use crate::ws::WsByteStream;
 
 /// Bind, accept, and serve until the listener errors. `listen_addr` is
@@ -32,8 +32,84 @@ use crate::ws::WsByteStream;
 /// (`SS_LOCAL_HOST:SS_LOCAL_PORT`).
 pub async fn run(listen_addr: &str, upstream_addr: &str, cfg: ServerCfg) -> Result<()> {
     let challenges = Arc::new(ChallengeStore::new());
-    let tls = Arc::new(build_tls_server(&cfg, challenges.clone()).await?);
+    // Bind the listener BEFORE running ACME: TLS-ALPN-01 validation
+    // requires the port-443 listener to be live (with the ALPN-select
+    // callback consulting `challenges`) when LE connects to validate.
     let listener = net::create_listener(listen_addr, cfg.fast_open).await?;
+    let tls = Arc::new(build_initial_tls(&cfg, challenges.clone())?);
+
+    // ACME mode: kick off issuance / renewal in the background. Until
+    // issuance completes the bootstrap (self-signed) acceptor handles
+    // TLS-ALPN-01 challenges; once the production cert is ready we hot-swap.
+    if let ServerTls::Acme {
+        email,
+        staging,
+        cache_dir,
+    } = &cfg.tls
+    {
+        let domains = compute_acme_domains(&cfg);
+        let cached = acme::load_cached(cache_dir);
+        let cfg_for_task = cfg.clone();
+        let challenges_for_task = challenges.clone();
+        let tls_for_task = tls.clone();
+        let email = email.clone();
+        let staging = *staging;
+        let cache_dir = cache_dir.clone();
+
+        if let Some(material) = cached {
+            tracing::info!("using cached cert from {}", cache_dir.display());
+            install_material(
+                &tls_for_task,
+                &cfg_for_task,
+                &material,
+                &challenges_for_task,
+            )?;
+            let cb = make_swap_cb(tls_for_task, cfg_for_task, challenges_for_task.clone());
+            acme::spawn_renewal_task(domains, email, staging, cache_dir, challenges_for_task, cb);
+        } else {
+            tracing::info!("issuing new cert via ACME (TLS-ALPN-01) for {domains:?}");
+            tokio::spawn(async move {
+                let domains_ref: Vec<&str> = domains.iter().map(String::as_str).collect();
+                match acme::issue(
+                    &domains_ref,
+                    &email,
+                    staging,
+                    &cache_dir,
+                    None,
+                    challenges_for_task.clone(),
+                )
+                .await
+                {
+                    Ok(material) => {
+                        if let Err(e) = install_material(
+                            &tls_for_task,
+                            &cfg_for_task,
+                            &material,
+                            &challenges_for_task,
+                        ) {
+                            tracing::error!("install ACME cert failed: {e:#}");
+                            return;
+                        }
+                        tracing::info!("ACME cert installed; production traffic now live");
+                        let cb =
+                            make_swap_cb(tls_for_task, cfg_for_task, challenges_for_task.clone());
+                        acme::spawn_renewal_task(
+                            domains,
+                            email,
+                            staging,
+                            cache_dir,
+                            challenges_for_task,
+                            cb,
+                        );
+                    }
+                    Err(e) => {
+                        tracing::error!("ACME issuance failed: {e:#}");
+                    }
+                }
+            });
+        }
+    }
+
     let cfg = Arc::new(cfg);
     let upstream = Arc::<str>::from(upstream_addr);
 
@@ -132,46 +208,72 @@ async fn handle_request(
         .expect("static 101 response is valid"))
 }
 
-/// Build a [`TlsServer`] from the config, dispatching on
-/// [`ServerTls::Static`] vs [`ServerTls::Acme`]. The ACME path may
-/// block on a network roundtrip to issue/refresh the cert.
-async fn build_tls_server(cfg: &ServerCfg, challenges: Arc<ChallengeStore>) -> Result<TlsServer> {
+/// Build the [`TlsServer`] used by the listener at startup. Static
+/// mode loads the cert/key from disk; ACME mode returns a *bootstrap*
+/// acceptor (self-signed throwaway cert as default) so the listener
+/// can come up immediately and serve TLS-ALPN-01 challenges while ACME
+/// runs in the background. The caller hot-swaps to the production
+/// cert once issuance succeeds.
+fn build_initial_tls(cfg: &ServerCfg, challenges: Arc<ChallengeStore>) -> Result<TlsServer> {
     match &cfg.tls {
         ServerTls::Static { .. } => TlsServer::build_static_with(cfg, challenges),
-        ServerTls::Acme {
-            email,
-            staging,
-            cache_dir,
-        } => {
-            let mut domains: Vec<&str> = vec![cfg.domain.as_str()];
-            if let Some(ech) = &cfg.ech {
-                if !ech.public_name.is_empty() && ech.public_name != cfg.domain {
-                    domains.push(ech.public_name.as_str());
-                }
-            }
-            let cert = match acme::load_cached(cache_dir) {
-                Some(c) => {
-                    tracing::info!("using cached cert from {}", cache_dir.display());
-                    c
-                }
-                None => {
-                    tracing::info!("issuing new cert via ACME (TLS-ALPN-01) for {domains:?}");
-                    acme::issue(
-                        &domains,
-                        email,
-                        *staging,
-                        cache_dir,
-                        None,
-                        challenges.clone(),
-                    )
-                    .await?
-                }
-            };
-            let server =
-                TlsServer::build_from_pem_with(cfg, &cert.cert_pem, &cert.key_pem, challenges)?;
-            Ok(server)
+        ServerTls::Acme { .. } => TlsServer::build_bootstrap_with(cfg, challenges),
+    }
+}
+
+/// Compute the SAN list for the ACME order: the real tunnel `domain`,
+/// plus the ECH `public_name` if set and distinct.
+fn compute_acme_domains(cfg: &ServerCfg) -> Vec<String> {
+    let mut out = vec![cfg.domain.clone()];
+    if let Some(ech) = &cfg.ech {
+        if !ech.public_name.is_empty() && ech.public_name != cfg.domain {
+            out.push(ech.public_name.clone());
         }
     }
+    out
+}
+
+/// Build an `SslAcceptor` from the freshly-issued PEM material and
+/// hot-swap it into the live `TlsServer`.
+fn install_material(
+    tls: &TlsServer,
+    cfg: &ServerCfg,
+    material: &acme::CertMaterial,
+    challenges: &Arc<ChallengeStore>,
+) -> Result<()> {
+    let acceptor = build_acceptor_from_pem_strs_pub(
+        &material.cert_pem,
+        &material.key_pem,
+        challenges.clone(),
+        cfg.ech.as_ref(),
+    )?;
+    tls.swap(acceptor);
+    Ok(())
+}
+
+/// Build the `on_new` callback handed to [`acme::spawn_renewal_task`]:
+/// rebuilds the acceptor from the renewed PEM and swaps it in. The
+/// rebuilt acceptor reuses the same `ChallengeStore` so subsequent
+/// renewals can again share the production listener for TLS-ALPN-01.
+fn make_swap_cb(
+    tls: Arc<TlsServer>,
+    cfg: ServerCfg,
+    challenges: Arc<ChallengeStore>,
+) -> Arc<dyn Fn(acme::CertMaterial) + Send + Sync> {
+    Arc::new(move |material: acme::CertMaterial| {
+        match build_acceptor_from_pem_strs_pub(
+            &material.cert_pem,
+            &material.key_pem,
+            challenges.clone(),
+            cfg.ech.as_ref(),
+        ) {
+            Ok(acceptor) => {
+                tls.swap(acceptor);
+                tracing::info!("renewed cert installed");
+            }
+            Err(e) => tracing::error!("renewal swap failed: {e:#}"),
+        }
+    })
 }
 
 fn is_ws_upgrade(req: &Request<Incoming>) -> bool {

--- a/src/tls_server.rs
+++ b/src/tls_server.rs
@@ -68,7 +68,24 @@ impl TlsServer {
         challenges: Arc<ChallengeStore>,
     ) -> Result<Self> {
         let acceptor =
-            build_acceptor_from_pem_strs(cert_pem, key_pem, challenges, cfg.ech.as_ref())?;
+            build_acceptor_from_pem_strs_pub(cert_pem, key_pem, challenges, cfg.ech.as_ref())?;
+        Ok(Self {
+            acceptor: Arc::new(ArcSwap::from_pointee(acceptor)),
+        })
+    }
+
+    /// Build a bootstrap acceptor with a self-signed throwaway cert as
+    /// the default. The ALPN+SNI callbacks still consult `challenges`,
+    /// so TLS-ALPN-01 validation works while the real ACME-issued cert
+    /// is being fetched. Real clients see an untrusted cert until the
+    /// production cert is swapped in.
+    pub fn build_bootstrap_with(cfg: &ServerCfg, challenges: Arc<ChallengeStore>) -> Result<Self> {
+        let kp = rcgen::generate_simple_self_signed(vec![cfg.domain.clone()])
+            .context("generate bootstrap self-signed cert")?;
+        let cert_pem = kp.cert.pem();
+        let key_pem = kp.key_pair.serialize_pem();
+        let acceptor =
+            build_acceptor_from_pem_strs_pub(&cert_pem, &key_pem, challenges, cfg.ech.as_ref())?;
         Ok(Self {
             acceptor: Arc::new(ArcSwap::from_pointee(acceptor)),
         })
@@ -104,6 +121,17 @@ fn build_acceptor_from_pem(
     install_alpn_callback(&mut b, challenges)?;
     install_ech_if_configured(&b, ech)?;
     Ok(b.build())
+}
+
+/// Crate-public variant so [`crate::server`] can build a fresh acceptor
+/// from a freshly-issued ACME cert and hot-swap it via [`TlsServer::swap`].
+pub(crate) fn build_acceptor_from_pem_strs_pub(
+    cert_pem: &str,
+    key_pem: &str,
+    challenges: Arc<ChallengeStore>,
+    ech: Option<&ServerEch>,
+) -> Result<SslAcceptor> {
+    build_acceptor_from_pem_strs(cert_pem, key_pem, challenges, ech)
 }
 
 fn build_acceptor_from_pem_strs(


### PR DESCRIPTION
## Summary

Two bugs prevented Let's Encrypt issuance and renewal from working as the README describes. Both are fixed here.

### Bug 1: ACME init order

`server::run` awaited `build_tls_server` (which calls `acme::issue` synchronously) **before** `create_listener`. So when LE connected to validate TLS-ALPN-01, the port-443 listener didn't exist yet — the order failed with `"Connection refused"` on every retry.

Caught by deploying \`v0.1.0\` against a real Let's Encrypt prod account: the authz state showed \`"detail": "159.65.12.53: Connection refused"\` on every order. The e2e test (\`tests/sip003_e2e.rs\`) uses static certs, so the ACME path was never exercised.

### Bug 2: renewal task is dead code

\`acme::spawn_renewal_task\` is exported but **never called**. Cached certs would simply expire in place.

## Fix

Refactor the ACME path:

- Listener binds first with a **bootstrap acceptor** (self-signed throwaway cert + the existing ALPN/SNI/ECH wiring) that handles the LE challenge while issuance is in flight.
- Issuance runs in a spawned task; on success the production cert is swapped in via the existing \`ArcSwap\`, and the renewal task is started with the same \`ChallengeStore\` so future renewals also share the listener.
- Cached-cert boot path also spawns the renewal task.

Also bumps \`instant-acme\` 0.7 → 0.8 — 0.7's authorization deserializer hit \`missing field \\\`token\\\`\` on Let's Encrypt staging responses; 0.8's handle/iterator API also fixes that. Adapted the call sites accordingly.

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --all-targets -- -D warnings\`
- [x] \`cargo test --lib\` — 60 passed
- [x] Deployed against real Let's Encrypt **staging** (\`acme_staging=true\`): cert issued in ~7s, listener live throughout
- [x] Switched to **production** (\`acme_staging=false\`): cert issued in ~7s, \`issuer = E7\`, valid 90 days
- [x] External \`openssl s_client\` confirms cert chain verifies
- [x] Stealth fake-nginx-404 still served on non-WS paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)