### PR TITLE
server: support unowned cover names + RST non-ECH probes

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,9 @@ on the wire) like an HTTPS connection to `front.example.com`.
 | `acme_email` | — | Contact email; enables ACME (Let's Encrypt) via TLS-ALPN-01. |
 | `acme_cache` | `/var/lib/ech-tls-tunnel/acme` | Where the ACME account + cert live across restarts. |
 | `acme_staging` | `false` | Use Let's Encrypt staging — set `true` while testing to avoid rate limits. |
-| `ech_public_name` | — | Outer SNI advertised to public observers. Required (with `ech_key`) to enable ECH. |
+| `acme_cover_san` | `true` | Include `ech_public_name` as a SAN on the ACME cert. Set `false` when the cover name is a domain you don't own (e.g. `www.baidu.com`); the cert then only covers `domain`. |
+| `ech_public_name` | — | Outer SNI advertised to public observers. Required (with `ech_key`) to enable ECH. Owning the name (with a SAN on the cert) holds up under active probing; an unowned cover name only hides the SNI from passive observers. |
+| `reject_non_ech` | `true` | Only meaningful when ECH is enabled. TCP-RST any inbound TLS handshake whose ClientHello lacks the `encrypted_client_hello` extension (and isn't an ACME `acme-tls/1` validator), so active probes can't observe the production cert. |
 | `ech_key` | — | Path to the HPKE private key from `ech-gen-keys`. |
 | `server_name` | `nginx/1.24.0` | Value of the `Server` header in fake-404 responses. |
 

--- a/src/clienthello.rs
+++ b/src/clienthello.rs
@@ -1,0 +1,286 @@
+//! Minimal TLS ClientHello peeker used to drop non-ECH probes before
+//! BoringSSL would otherwise terminate the handshake and reveal a
+//! cert mismatch (cover name vs. real `domain`).
+//!
+//! Parses just enough of the record layer + handshake header to find
+//! the extension list, then scans for:
+//!
+//! - `encrypted_client_hello` (ext type 0xfe0d) — a real client.
+//! - `application_layer_protocol_negotiation` carrying `acme-tls/1`
+//!   (RFC 8737) — Let's Encrypt validator. Must not be dropped or
+//!   ACME issuance/renewal breaks.
+//!
+//! Returns [`ClientHelloKind::Other`] for anything else. The caller
+//! is expected to RST the connection in that case.
+
+const EXT_ECH: u16 = 0xfe0d;
+const EXT_ALPN: u16 = 0x0010;
+const ACME_ALPN: &[u8] = b"acme-tls/1";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClientHelloKind {
+    /// Buffer doesn't contain a complete ClientHello yet; caller may
+    /// read more bytes (up to its budget) before deciding.
+    Incomplete,
+    /// First byte isn't a TLS handshake record (0x16). Drop.
+    NotTls,
+    /// ClientHello carries the ECH extension or `acme-tls/1` ALPN.
+    EchOrAcmeAlpn,
+    /// Parsed a ClientHello, but it has neither signal. Drop.
+    Other,
+}
+
+/// Classify the bytes at the start of a TCP connection. Never
+/// allocates; bounded scan limited to one TLS record.
+pub fn classify(buf: &[u8]) -> ClientHelloKind {
+    let mut r = Reader::new(buf);
+
+    // TLS record layer: type(1) version(2) length(2)
+    let Some(record_type) = r.read_u8() else {
+        return ClientHelloKind::Incomplete;
+    };
+    if record_type != 0x16 {
+        return ClientHelloKind::NotTls;
+    }
+    if r.skip(2).is_none() {
+        return ClientHelloKind::Incomplete;
+    }
+    let Some(record_len) = r.read_u16() else {
+        return ClientHelloKind::Incomplete;
+    };
+    let Some(record) = r.read_slice(record_len as usize) else {
+        return ClientHelloKind::Incomplete;
+    };
+    let mut r = Reader::new(record);
+
+    // Handshake header: type(1) length(3)
+    let Some(hs_type) = r.read_u8() else {
+        return ClientHelloKind::Incomplete;
+    };
+    if hs_type != 0x01 {
+        return ClientHelloKind::Other;
+    }
+    let Some(hs_len) = r.read_u24() else {
+        return ClientHelloKind::Incomplete;
+    };
+    let Some(body) = r.read_slice(hs_len as usize) else {
+        return ClientHelloKind::Incomplete;
+    };
+    let mut r = Reader::new(body);
+
+    // ClientHello body, skipping past the fields we don't care about.
+    if r.skip(2 + 32).is_none() {
+        return ClientHelloKind::Incomplete;
+    }
+    let Some(sid_len) = r.read_u8() else {
+        return ClientHelloKind::Incomplete;
+    };
+    if r.skip(sid_len as usize).is_none() {
+        return ClientHelloKind::Incomplete;
+    }
+    let Some(cs_len) = r.read_u16() else {
+        return ClientHelloKind::Incomplete;
+    };
+    if r.skip(cs_len as usize).is_none() {
+        return ClientHelloKind::Incomplete;
+    }
+    let Some(comp_len) = r.read_u8() else {
+        return ClientHelloKind::Incomplete;
+    };
+    if r.skip(comp_len as usize).is_none() {
+        return ClientHelloKind::Incomplete;
+    }
+    let Some(ext_len) = r.read_u16() else {
+        return ClientHelloKind::Other;
+    };
+    let Some(exts) = r.read_slice(ext_len as usize) else {
+        return ClientHelloKind::Incomplete;
+    };
+
+    let mut r = Reader::new(exts);
+    while !r.is_empty() {
+        let Some(ext_type) = r.read_u16() else {
+            return ClientHelloKind::Other;
+        };
+        let Some(ext_data_len) = r.read_u16() else {
+            return ClientHelloKind::Other;
+        };
+        let Some(ext_data) = r.read_slice(ext_data_len as usize) else {
+            return ClientHelloKind::Other;
+        };
+        if ext_type == EXT_ECH {
+            return ClientHelloKind::EchOrAcmeAlpn;
+        }
+        if ext_type == EXT_ALPN && alpn_has_acme(ext_data) {
+            return ClientHelloKind::EchOrAcmeAlpn;
+        }
+    }
+
+    ClientHelloKind::Other
+}
+
+fn alpn_has_acme(ext_data: &[u8]) -> bool {
+    let mut r = Reader::new(ext_data);
+    let Some(list_len) = r.read_u16() else {
+        return false;
+    };
+    let Some(list) = r.read_slice(list_len as usize) else {
+        return false;
+    };
+    let mut r = Reader::new(list);
+    while !r.is_empty() {
+        let Some(name_len) = r.read_u8() else {
+            return false;
+        };
+        let Some(name) = r.read_slice(name_len as usize) else {
+            return false;
+        };
+        if name == ACME_ALPN {
+            return true;
+        }
+    }
+    false
+}
+
+struct Reader<'a> {
+    buf: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Reader<'a> {
+    fn new(buf: &'a [u8]) -> Self {
+        Self { buf, pos: 0 }
+    }
+    fn is_empty(&self) -> bool {
+        self.pos >= self.buf.len()
+    }
+    fn read_u8(&mut self) -> Option<u8> {
+        let b = *self.buf.get(self.pos)?;
+        self.pos += 1;
+        Some(b)
+    }
+    fn read_u16(&mut self) -> Option<u16> {
+        let s = self.buf.get(self.pos..self.pos + 2)?;
+        self.pos += 2;
+        Some(u16::from_be_bytes([s[0], s[1]]))
+    }
+    fn read_u24(&mut self) -> Option<u32> {
+        let s = self.buf.get(self.pos..self.pos + 3)?;
+        self.pos += 3;
+        Some(u32::from_be_bytes([0, s[0], s[1], s[2]]))
+    }
+    fn skip(&mut self, n: usize) -> Option<()> {
+        self.buf.get(self.pos..self.pos + n)?;
+        self.pos += n;
+        Some(())
+    }
+    fn read_slice(&mut self, n: usize) -> Option<&'a [u8]> {
+        let s = self.buf.get(self.pos..self.pos + n)?;
+        self.pos += n;
+        Some(s)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Wrap an already-built handshake body in TLS record + handshake
+    /// headers, then run classify on the result.
+    fn classify_with_record(hs_body: &[u8]) -> ClientHelloKind {
+        let mut hs = vec![0x01]; // ClientHello
+        let len = hs_body.len() as u32;
+        hs.extend_from_slice(&[(len >> 16) as u8, (len >> 8) as u8, len as u8]);
+        hs.extend_from_slice(hs_body);
+
+        let mut record = vec![0x16, 0x03, 0x01]; // handshake, TLS 1.0 legacy
+        let l = hs.len() as u16;
+        record.extend_from_slice(&l.to_be_bytes());
+        record.extend_from_slice(&hs);
+        classify(&record)
+    }
+
+    fn build_hello(extensions: &[(u16, &[u8])]) -> Vec<u8> {
+        let mut body = Vec::new();
+        body.extend_from_slice(&[0x03, 0x03]); // legacy_version
+        body.extend_from_slice(&[0u8; 32]); // random
+        body.push(0); // session_id len
+        body.extend_from_slice(&[0x00, 0x02, 0x13, 0x01]); // 1 cipher suite
+        body.extend_from_slice(&[0x01, 0x00]); // 1 compression
+        let mut exts = Vec::new();
+        for (ty, data) in extensions {
+            exts.extend_from_slice(&ty.to_be_bytes());
+            exts.extend_from_slice(&(data.len() as u16).to_be_bytes());
+            exts.extend_from_slice(data);
+        }
+        body.extend_from_slice(&(exts.len() as u16).to_be_bytes());
+        body.extend_from_slice(&exts);
+        body
+    }
+
+    fn alpn_ext(names: &[&[u8]]) -> Vec<u8> {
+        let mut list = Vec::new();
+        for n in names {
+            list.push(n.len() as u8);
+            list.extend_from_slice(n);
+        }
+        let mut out = Vec::new();
+        out.extend_from_slice(&(list.len() as u16).to_be_bytes());
+        out.extend_from_slice(&list);
+        out
+    }
+
+    #[test]
+    fn empty_is_incomplete() {
+        assert_eq!(classify(&[]), ClientHelloKind::Incomplete);
+    }
+
+    #[test]
+    fn non_handshake_record_is_not_tls() {
+        assert_eq!(
+            classify(&[0x17, 0x03, 0x03, 0, 1, 0]),
+            ClientHelloKind::NotTls
+        );
+    }
+
+    #[test]
+    fn truncated_record_is_incomplete() {
+        let hello = build_hello(&[(EXT_ECH, &[0u8; 4])]);
+        let mut record = vec![0x16, 0x03, 0x01];
+        record.extend_from_slice(&(hello.len() as u16 + 4).to_be_bytes());
+        record.push(0x01);
+        record.extend_from_slice(&[
+            (hello.len() >> 16) as u8,
+            (hello.len() >> 8) as u8,
+            hello.len() as u8,
+        ]);
+        record.extend_from_slice(&hello[..hello.len() / 2]);
+        assert_eq!(classify(&record), ClientHelloKind::Incomplete);
+    }
+
+    #[test]
+    fn ech_extension_passes() {
+        let hello = build_hello(&[(EXT_ECH, &[0u8; 8])]);
+        assert_eq!(classify_with_record(&hello), ClientHelloKind::EchOrAcmeAlpn);
+    }
+
+    #[test]
+    fn acme_alpn_passes() {
+        let alpn = alpn_ext(&[ACME_ALPN]);
+        let hello = build_hello(&[(EXT_ALPN, &alpn)]);
+        assert_eq!(classify_with_record(&hello), ClientHelloKind::EchOrAcmeAlpn);
+    }
+
+    #[test]
+    fn ordinary_alpn_does_not_pass() {
+        let alpn = alpn_ext(&[b"h2", b"http/1.1"]);
+        let hello = build_hello(&[(EXT_ALPN, &alpn)]);
+        assert_eq!(classify_with_record(&hello), ClientHelloKind::Other);
+    }
+
+    #[test]
+    fn no_relevant_extensions_is_other() {
+        let hello = build_hello(&[(0x002b, &[0x02, 0x03, 0x04])]); // supported_versions
+        assert_eq!(classify_with_record(&hello), ClientHelloKind::Other);
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,7 +18,15 @@
 //! - `acme_email=<addr>` (auto cert via Let's Encrypt)
 //! - `acme_cache=<dir>` (default `/var/lib/ech-tls-tunnel/acme`)
 //! - `acme_staging=true|false` (default `false`)
+//! - `acme_cover_san=true|false` (default `true`) — include
+//!   `ech_public_name` as a SAN on the ACME cert. Set to `false` when
+//!   the cover name is a domain you don't own (e.g. `www.baidu.com`)
+//!   so the order only requests a cert for `domain`.
 //! - `ech_public_name=<name>` + `ech_key=<path>` (both required for ECH)
+//! - `reject_non_ech=true|false` (default `true`, only meaningful when
+//!   ECH is enabled) — TCP-RST any inbound TLS handshake that lacks
+//!   the ECH extension (and isn't an ACME `acme-tls/1` validator), so
+//!   active probes don't observe the production cert.
 //! - `server_name=<header value>` (default `nginx/1.24.0`)
 //!
 //! Client (`mode=client`):
@@ -63,6 +71,13 @@ pub struct ServerCfg {
     pub tls: ServerTls,
     /// ECH HPKE keys; `None` disables ECH.
     pub ech: Option<ServerEch>,
+    /// Include `ech_public_name` as a SAN on the ACME cert when distinct
+    /// from `domain`. Set `false` when the cover name is a domain you
+    /// don't own — ACME issuance would otherwise fail.
+    pub acme_cover_san: bool,
+    /// When ECH is enabled, drop (TCP-RST) inbound TLS handshakes that
+    /// don't carry the ECH extension and aren't ACME validators.
+    pub reject_non_ech: bool,
     /// `Server` header value for fake-404 responses.
     pub server_name: String,
 }
@@ -133,6 +148,8 @@ impl ServerCfg {
         let fast_open = parse_bool(o, "fast_open")?.unwrap_or(false);
         let tls = build_server_tls(o)?;
         let ech = build_server_ech(o)?;
+        let acme_cover_san = parse_bool(o, "acme_cover_san")?.unwrap_or(true);
+        let reject_non_ech = parse_bool(o, "reject_non_ech")?.unwrap_or(true);
         let server_name = o
             .get("server_name")
             .map(str::to_string)
@@ -144,6 +161,8 @@ impl ServerCfg {
             fast_open,
             tls,
             ech,
+            acme_cover_san,
+            reject_non_ech,
             server_name,
         })
     }
@@ -381,6 +400,36 @@ mod tests {
             err_str("mode=server;domain=t.x;path=/ws;cert=/c;key=/k;ech_key=/e.key")
                 .contains("ech_public_name")
         );
+    }
+
+    #[test]
+    fn server_acme_cover_san_default_true() {
+        let c = server_cfg(
+            "mode=server;domain=t.x;path=/ws;acme_email=a@b.c;\
+             ech_public_name=front.x;ech_key=/e.key",
+        );
+        assert!(c.acme_cover_san);
+    }
+
+    #[test]
+    fn server_acme_cover_san_opt_out() {
+        let c = server_cfg(
+            "mode=server;domain=t.x;path=/ws;acme_email=a@b.c;\
+             ech_public_name=www.baidu.com;ech_key=/e.key;acme_cover_san=false",
+        );
+        assert!(!c.acme_cover_san);
+    }
+
+    #[test]
+    fn server_reject_non_ech_default_true() {
+        let c = server_cfg("mode=server;domain=t.x;path=/ws;cert=/c;key=/k");
+        assert!(c.reject_non_ech);
+    }
+
+    #[test]
+    fn server_reject_non_ech_opt_out() {
+        let c = server_cfg("mode=server;domain=t.x;path=/ws;cert=/c;key=/k;reject_non_ech=false");
+        assert!(!c.reject_non_ech);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 pub mod acme;
 pub mod challenge;
 pub mod client;
+pub mod clienthello;
 pub mod config;
 pub mod ech;
 pub mod fingerprint;

--- a/src/server.rs
+++ b/src/server.rs
@@ -20,6 +20,7 @@ use tracing::{debug, warn};
 
 use crate::acme;
 use crate::challenge::ChallengeStore;
+use crate::clienthello::{self, ClientHelloKind};
 use crate::config::{ServerCfg, ServerTls};
 use crate::net;
 use crate::stealth;
@@ -127,6 +128,11 @@ pub async fn run(listen_addr: &str, upstream_addr: &str, cfg: ServerCfg) -> Resu
         let upstream = upstream.clone();
 
         tokio::spawn(async move {
+            if cfg.ech.is_some() && cfg.reject_non_ech && !is_ech_or_acme_handshake(&tcp).await {
+                rst_drop(tcp);
+                debug!("{peer}: dropped non-ECH handshake");
+                return;
+            }
             let stream = match tls.accept(tcp).await {
                 Ok(s) => s,
                 Err(e) => {
@@ -222,12 +228,16 @@ fn build_initial_tls(cfg: &ServerCfg, challenges: Arc<ChallengeStore>) -> Result
 }
 
 /// Compute the SAN list for the ACME order: the real tunnel `domain`,
-/// plus the ECH `public_name` if set and distinct.
+/// plus the ECH `public_name` if set, distinct, and `acme_cover_san`
+/// is on. Users with an unowned cover name (e.g. `www.baidu.com`) must
+/// set `acme_cover_san=false` so the order only requests `domain`.
 fn compute_acme_domains(cfg: &ServerCfg) -> Vec<String> {
     let mut out = vec![cfg.domain.clone()];
-    if let Some(ech) = &cfg.ech {
-        if !ech.public_name.is_empty() && ech.public_name != cfg.domain {
-            out.push(ech.public_name.clone());
+    if cfg.acme_cover_san {
+        if let Some(ech) = &cfg.ech {
+            if !ech.public_name.is_empty() && ech.public_name != cfg.domain {
+                out.push(ech.public_name.clone());
+            }
         }
     }
     out
@@ -274,6 +284,51 @@ fn make_swap_cb(
             Err(e) => tracing::error!("renewal swap failed: {e:#}"),
         }
     })
+}
+
+/// Peek up to 8 KiB and decide whether the inbound bytes look like a
+/// ClientHello carrying ECH (real client) or `acme-tls/1` ALPN (Let's
+/// Encrypt validator). Returns `false` for anything else, including
+/// reads that time out before a full ClientHello arrives.
+async fn is_ech_or_acme_handshake(tcp: &tokio::net::TcpStream) -> bool {
+    use std::time::Duration;
+
+    const PEEK_CAP: usize = 8 * 1024;
+    const PEEK_BUDGET: Duration = Duration::from_secs(5);
+    const POLL_INTERVAL: Duration = Duration::from_millis(20);
+
+    let mut buf = vec![0u8; PEEK_CAP];
+    let deadline = tokio::time::Instant::now() + PEEK_BUDGET;
+    let mut last_n = 0usize;
+    loop {
+        let read = tokio::time::timeout_at(deadline, tcp.peek(&mut buf)).await;
+        let n = match read {
+            Ok(Ok(0)) => return false,
+            Ok(Ok(n)) => n,
+            Ok(Err(_)) | Err(_) => return false,
+        };
+        match clienthello::classify(&buf[..n]) {
+            ClientHelloKind::EchOrAcmeAlpn => return true,
+            ClientHelloKind::NotTls | ClientHelloKind::Other => return false,
+            ClientHelloKind::Incomplete => {
+                if n == buf.len() || tokio::time::Instant::now() >= deadline {
+                    return false;
+                }
+                if n == last_n {
+                    tokio::time::sleep(POLL_INTERVAL).await;
+                }
+                last_n = n;
+            }
+        }
+    }
+}
+
+/// Force a TCP RST on the dropped socket so the peer cannot tell our
+/// production cert apart from a hung listener.
+fn rst_drop(tcp: tokio::net::TcpStream) {
+    let sock = socket2::SockRef::from(&tcp);
+    let _ = sock.set_linger(Some(std::time::Duration::ZERO));
+    drop(tcp);
 }
 
 fn is_ws_upgrade(req: &Request<Incoming>) -> bool {

--- a/src/tls_client.rs
+++ b/src/tls_client.rs
@@ -168,6 +168,8 @@ mod tests {
                 key_file: key_path,
             },
             ech: None::<ServerEch>,
+            acme_cover_san: true,
+            reject_non_ech: true,
             server_name: "nginx/1.24.0".into(),
         };
         let server = TlsServer::build_static(&cfg).unwrap();

--- a/src/tls_server.rs
+++ b/src/tls_server.rs
@@ -304,6 +304,8 @@ mod tests {
                 key_file: key_path,
             },
             ech: None::<ServerEch>,
+            acme_cover_san: true,
+            reject_non_ech: true,
             server_name: "nginx/1.24.0".into(),
         }
     }
@@ -360,6 +362,8 @@ mod tests {
                 cache_dir: "/tmp".into(),
             },
             ech: None,
+            acme_cover_san: true,
+            reject_non_ech: true,
             server_name: "nginx/1.24.0".into(),
         };
         let err = TlsServer::build_static(&cfg).unwrap_err();

--- a/tests/loops_e2e.rs
+++ b/tests/loops_e2e.rs
@@ -91,6 +91,8 @@ async fn full_loop_round_trips_payload() {
                 key_file: key_path,
             },
             ech: None,
+            acme_cover_san: true,
+            reject_non_ech: true,
             server_name: "nginx/1.24.0".into(),
         };
         let server_listen = tunnel_addr.clone();
@@ -157,6 +159,8 @@ async fn unmatched_path_serves_fake_404() {
                 key_file: key_path,
             },
             ech: None,
+            acme_cover_san: true,
+            reject_non_ech: true,
             server_name: "nginx/1.24.0".into(),
         };
         let listen = tunnel_addr.clone();


### PR DESCRIPTION
## Summary
- Adds `acme_cover_san=true|false` (default `true`) — opt out of including `ech_public_name` as a SAN on the ACME cert, so cover names the operator doesn't own (e.g. `www.baidu.com`) don't break issuance.
- Adds `reject_non_ech=true|false` (default `true`, only meaningful when ECH is on) — TCP-RST any inbound TLS handshake whose ClientHello lacks `encrypted_client_hello` (and isn't an ACME `acme-tls/1` validator), so active probes can't observe the production cert.
- New `src/clienthello.rs`: zero-alloc TLS record + ClientHello parser used by the accept loop to classify inbound bytes before BoringSSL terminates the handshake.

## Threat-model context
ECH only hides the inner SNI when `public_name != domain`. With an unowned cover name, two things break out of the box: ACME refuses to issue, and active probes see a cert that doesn't match the cover. This PR makes both knobs operator-configurable for the passive-DPI threat model. README documents the tradeoff.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --lib` — 71 passed (4 new config tests + 7 new clienthello tests)
- [ ] e2e (`cargo test --tests`) on a host with `ssserver`/`sslocal`/`curl`
- [ ] live deploy: rotate `sgp.maxlv.net` to a cover name with `acme_cover_san=false`; verify renewal still works and non-ECH probes get RST

🤖 Generated with [Claude Code](https://claude.com/claude-code)