### PR TITLE
release: add musl static builds for amd64 + arm64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,12 +18,23 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             suffix: linux-amd64
+            use_cross: false
           - os: ubuntu-22.04-arm
             target: aarch64-unknown-linux-gnu
             suffix: linux-arm64
+            use_cross: false
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            suffix: linux-amd64-musl
+            use_cross: true
+          - os: ubuntu-22.04-arm
+            target: aarch64-unknown-linux-musl
+            suffix: linux-arm64-musl
+            use_cross: true
           - os: macos-latest
             target: aarch64-apple-darwin
             suffix: darwin-arm64
+            use_cross: false
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -31,8 +42,17 @@ jobs:
         with:
           targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2
+      - name: Install cross
+        if: matrix.use_cross
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cross
       - name: cargo build --release
+        if: '!matrix.use_cross'
         run: cargo build --release --target ${{ matrix.target }} --bin ech-tls-tunnel
+      - name: cross build --release
+        if: matrix.use_cross
+        run: cross build --release --target ${{ matrix.target }} --bin ech-tls-tunnel
       - name: Package
         shell: bash
         run: |

--- a/README.md
+++ b/README.md
@@ -33,14 +33,20 @@ Pick a release binary from the
 extract, and put `ech-tls-tunnel` somewhere on `PATH`:
 
 ```sh
-# Linux x86_64
+# Linux x86_64 (glibc — Ubuntu/Debian/RHEL/etc.)
 curl -L https://github.com/shadowsocks/ech-tls-tunnel/releases/latest/download/ech-tls-tunnel-linux-amd64.tar.gz | tar xz
+sudo mv ech-tls-tunnel /usr/local/bin/
+
+# Linux x86_64 (musl, fully static — Alpine, OpenWrt, embedded)
+curl -L https://github.com/shadowsocks/ech-tls-tunnel/releases/latest/download/ech-tls-tunnel-linux-amd64-musl.tar.gz | tar xz
 sudo mv ech-tls-tunnel /usr/local/bin/
 
 # macOS arm64
 curl -L https://github.com/shadowsocks/ech-tls-tunnel/releases/latest/download/ech-tls-tunnel-darwin-arm64.tar.gz | tar xz
 sudo mv ech-tls-tunnel /usr/local/bin/
 ```
+
+`linux-arm64` and `linux-arm64-musl` builds are also published.
 
 Or build from source:
 


### PR DESCRIPTION
## Summary
- Add `linux-amd64-musl` and `linux-arm64-musl` to the release matrix so OpenWrt / Alpine / embedded users can grab a fully static binary without a system glibc.
- Build the musl targets via [`cross`](https://github.com/cross-rs/cross) — its prebuilt Docker image has the musl C/C++ toolchain that BoringSSL's CMake step needs (`<target>-g++`). Stock GitHub runners don't ship that, which is why `cargo build --target *-musl` fails today (#11).
- Other targets keep the existing `cargo build` path; only the two new musl rows route through `cross`.
- README updated with the new download URL and a note about who the musl build is for.

Closes #11.

## Test plan
- [ ] Tag a release (or `workflow_dispatch` the Release workflow) and confirm both `ech-tls-tunnel-linux-amd64-musl.tar.gz` and `ech-tls-tunnel-linux-arm64-musl.tar.gz` are produced and uploaded.
- [ ] On the artifact: `file ech-tls-tunnel` reports `statically linked`, and `ldd ech-tls-tunnel` says "not a dynamic executable".
- [ ] Smoke-test the binary on a glibc-free host (Alpine container or OpenWrt device) — runs `ech-tls-tunnel --version` without dynamic-linker errors.

If the cross image turns out to be missing perl/cmake for `boring-sys`, follow-up is a `Cross.toml` with a `pre-build` apt step — non-blocking for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)