### PR TITLE
release: v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -433,7 +433,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "ech-tls-tunnel"
-version = "0.1.0-dev"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ech-tls-tunnel"
-version = "0.1.0-dev"
+version = "0.1.1"
 edition = "2021"
 description = "SIP003 plugin: shadowsocks over WebSocket / TLS / ECH with ACME auto-renewal"
 license = "MIT"


### PR DESCRIPTION
Bumps \`Cargo.toml\` to **v0.1.1**.

## Highlights vs v0.1.0

- **Server**: support unowned cover names (\`acme_cover_san=false\`), TCP-RST non-ECH probes (\`reject_non_ech=true\`), ACME auto-renewal.
- **Net**: macOS client TFO via \`connectx(2)\` (\`setsockopt(TCP_FASTOPEN)\` was rejected with \`EINVAL\` on Apple); listener TFO is Linux-only.
- **Skill**: \`deploy-ech-tunnel\` playbook with sysctl tuning (BBR, \`fq\`, \`tcp_fastopen=3\`, BDP buffers) and \`fast_open=true\` wired into both server + client.
- **Build**: musl static binaries for amd64 + arm64.

After merge, tag \`v0.1.1\` on \`main\` to trigger \`release.yml\` (5-target matrix → GitHub Release with tarballs + sha256).

🤖 Generated with [Claude Code](https://claude.com/claude-code)