### PR TITLE
ci(release): build linux-arm64-musl on x86 host via cross

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
             target: x86_64-unknown-linux-musl
             suffix: linux-amd64-musl
             use_cross: true
-          - os: ubuntu-22.04-arm
+          - os: ubuntu-latest
             target: aarch64-unknown-linux-musl
             suffix: linux-arm64-musl
             use_cross: true


### PR DESCRIPTION
v0.1.1 release run failed at the linux-arm64-musl job — `cross` on the arm64 runner can't install the x86_64 host toolchain it needs. Move the matrix entry back to `ubuntu-latest` (matches `linux-amd64-musl`); cross handles the arm64-musl cross-compile via its docker image.

The other 4 builds (linux-amd64, linux-amd64-musl, linux-arm64, darwin-arm64) all succeeded, just the release job was skipped because of this single failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)